### PR TITLE
Added a CLI option for the report format

### DIFF
--- a/src/main/java/com/github/maracas/roseau/Roseau.java
+++ b/src/main/java/com/github/maracas/roseau/Roseau.java
@@ -109,7 +109,8 @@ final class Roseau implements Callable<Integer>  {
 				case "json":
 					JsonFormatter formatter = new JsonFormatter();
 					String bcsJson = formatter.format(bcs);
-					report = modifyReportExtension(".json", report);
+					if (!isGoodExtension(report.toString(),".json"))
+						report = modifyReportExtension(".json", report);
 					try (FileWriter writer = new FileWriter(report.toFile(), StandardCharsets.UTF_8)) {
 						writer.write(bcsJson);
 					}
@@ -118,7 +119,7 @@ final class Roseau implements Callable<Integer>  {
 					diff.writeReport(report);
 					break;
 			}
-			
+
 			return bcs;
 		} catch (InterruptedException | ExecutionException e) {
 			Thread.currentThread().interrupt();
@@ -132,6 +133,10 @@ final class Roseau implements Callable<Integer>  {
 
 	public Path modifyReportExtension(String format, Path report) {
 		return report.resolveSibling(report.getFileName() + format);
+	}
+
+	public boolean isGoodExtension(String extension, String format) {
+		return extension.endsWith(format);
 	}
 
 	private String format(BreakingChange bc) {

--- a/src/main/java/com/github/maracas/roseau/Roseau.java
+++ b/src/main/java/com/github/maracas/roseau/Roseau.java
@@ -7,6 +7,7 @@ import com.github.maracas.roseau.api.model.SourceLocation;
 import com.github.maracas.roseau.diff.APIDiff;
 import com.github.maracas.roseau.diff.changes.BreakingChange;
 import com.github.maracas.roseau.diff.formatter.JsonFormatter;
+import com.github.maracas.roseau.diff.formatter.ReportFormatType;
 import com.google.common.base.Stopwatch;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -64,9 +65,9 @@ final class Roseau implements Callable<Integer>  {
 			defaultValue = "false")
 	private boolean failMode;
 	@CommandLine.Option(names = "--format",
-			description="Format of the report; defaults to csv",
-			defaultValue="csv")
-	private String format;
+			description="Format of the report; defaults to csv; possible values: ${COMPLETION-CANDIDATES}",
+			defaultValue="CSV")
+	private ReportFormatType format;
 
 	private static final Logger logger = LogManager.getLogger(Roseau.class);
 
@@ -105,8 +106,8 @@ final class Roseau implements Callable<Integer>  {
 			List<BreakingChange> bcs = diff.diff();
 			logger.info("API diff took {}ms ({} breaking changes)", sw.elapsed().toMillis(), bcs.size());
 
-			switch (format.toLowerCase()) {
-				case "json":
+			switch (format) {
+				case JSON:
 					JsonFormatter formatter = new JsonFormatter();
 					String bcsJson = formatter.format(bcs);
 					if (!isGoodExtension(report.toString(),".json"))

--- a/src/main/java/com/github/maracas/roseau/diff/formatter/ReportFormatType.java
+++ b/src/main/java/com/github/maracas/roseau/diff/formatter/ReportFormatType.java
@@ -1,0 +1,9 @@
+package com.github.maracas.roseau.diff.formatter;
+
+/**
+ * Enumerates the possible formats for the report output. Currently supports JSON and CSV.
+ */
+public enum ReportFormatType {
+    JSON,
+    CSV
+}


### PR DESCRIPTION
With the option --format, the user can now choose the report format.

This format is CSV by default, but it can also be JSON. If the specified path for the report does not contain the desired format extension, we add it at the end of the path.