### PR TITLE
Maven plug-in brainstorming

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -38,6 +38,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.github.alien-tools</groupId>
+            <artifactId>roseau-core</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.9.9</version>
@@ -53,6 +58,43 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>
             <version>2.2.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>2.2.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>2.0.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-impl</artifactId>
+            <version>2.0.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-connector-basic</artifactId>
+            <version>2.0.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-http</artifactId>
+            <version>1.9.22</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.alien-tools</groupId>
+        <artifactId>roseau-parent</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>roseau-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <description>Maven plugin for Roseau</description>
+
+    <properties>
+        <maven-plugin-tools.version>3.15.1</maven-plugin-tools.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-tools.version}</version>
+                <executions>
+                    <execution>
+                        <id>help-mojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.9.9</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven-plugin-tools.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/maven-plugin/src/main/java/io/github/alien/roseau/maven/RoseauMojo.java
+++ b/maven-plugin/src/main/java/io/github/alien/roseau/maven/RoseauMojo.java
@@ -1,17 +1,132 @@
 package io.github.alien.roseau.maven;
 
+import io.github.alien.roseau.api.model.API;
+import io.github.alien.roseau.diff.APIDiff;
+import io.github.alien.roseau.diff.changes.BreakingChange;
+import io.github.alien.roseau.extractors.asm.AsmAPIExtractor;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+import java.util.List;
 
 @Mojo(name = "check")
 public class RoseauMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project}", required = true, readonly = true)
-	MavenProject project;
+	private MavenProject project;
+
+	@Parameter(property = "roseau.skip", defaultValue = "false")
+	private boolean skip;
+
+	@Parameter(property = "roseau.failOnBinaryIncompatibility", defaultValue = "false")
+	private boolean failOnBinaryIncompatibility;
+
+	@Parameter(property = "roseau.failOnSourceIncompatibility", defaultValue = "false")
+	private boolean failOnSourceIncompatibility;
+
+	@Parameter(property = "roseau.oldVersion")
+	private Dependency oldVersion;
+
+	@Inject
+	private RepositorySystem repositorySystem;
+
+	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+	private RepositorySystemSession repositorySystemSession;
+
+	@Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true)
+	private List<RemoteRepository> remoteRepositories;
 
 	@Override
-	public void execute() throws MojoExecutionException	{
+	public void execute() throws MojoExecutionException {
+		if (skip) {
+			getLog().info("Skipping.");
+			return;
+		}
+
+		if (oldVersion == null) {
+			getLog().warn("No oldVersion specified; skipping.");
+			return;
+		}
+
+		Path builtJar = getBuiltJar();
+		if (!builtJar.toFile().exists()) {
+			getLog().warn("Built JAR file " + builtJar + " not found; skipping.");
+			return;
+		}
+
+		Path oldVersionJar = resolveOldVersionJar();
+		if (!oldVersionJar.toFile().exists()) {
+			getLog().warn("Old version JAR file not found; skipping.");
+			return;
+		}
+
+		List<BreakingChange> bcs = compare(builtJar, oldVersionJar);
+		bcs.forEach(bc -> {
+			getLog().warn(format(bc));
+		});
+
+		if (bcs.stream().anyMatch(bc -> bc.kind().isBinaryBreaking()) && failOnBinaryIncompatibility) {
+			throw new MojoExecutionException("Binary incompatible changes found.");
+		}
+
+		if (bcs.stream().anyMatch(bc -> bc.kind().isSourceBreaking()) && failOnSourceIncompatibility) {
+			throw new MojoExecutionException("Source incompatible changes found.");
+		}
 	}
+
+	private List<BreakingChange> compare(Path oldJar, Path newJar) {
+		API oldApi = buildAPI(oldJar);
+		API newApi = buildAPI(newJar);
+
+		return new APIDiff(oldApi, newApi).diff();
+	}
+
+	private API buildAPI(Path jar) {
+		AsmAPIExtractor extractor = new AsmAPIExtractor();
+		return extractor.extractAPI(jar);
+	}
+
+	private Path getBuiltJar() {
+		return Path.of(project.getBuild().getDirectory(), project.getBuild().getFinalName() + ".jar");
+	}
+
+	private Path resolveOldVersionJar() throws MojoExecutionException {
+		try {
+			String coords = "%s:%s:%s".formatted(oldVersion.getGroupId(), oldVersion.getArtifactId(), oldVersion.getVersion());
+			DefaultArtifact artifact = new DefaultArtifact(coords);
+			ArtifactRequest request = new ArtifactRequest()
+				.setArtifact(artifact)
+				.setRepositories(remoteRepositories);
+
+			ArtifactResult result = repositorySystem.resolveArtifact(repositorySystemSession, request);
+			return result.getArtifact().getFile().toPath();
+		} catch (ArtifactResolutionException e) {
+			throw new MojoExecutionException("Error resolving old version JAR", e);
+		}
+	}
+
+	private String format(BreakingChange bc) {
+		return String.format("%s %s%n\t%s:%s",
+			RED_TEXT + BOLD + bc.kind() + RESET,
+			UNDERLINE + bc.impactedSymbol().getQualifiedName() + RESET,
+			bc.impactedSymbol().getLocation().file(),
+			bc.impactedSymbol().getLocation().line());
+	}
+
+	private static final String RED_TEXT = "\u001B[31m";
+	private static final String BOLD = "\u001B[1m";
+	private static final String UNDERLINE = "\u001B[4m";
+	private static final String RESET = "\u001B[0m";
 }

--- a/maven-plugin/src/main/java/io/github/alien/roseau/maven/RoseauMojo.java
+++ b/maven-plugin/src/main/java/io/github/alien/roseau/maven/RoseauMojo.java
@@ -1,0 +1,17 @@
+package io.github.alien.roseau.maven;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+@Mojo(name = "check")
+public class RoseauMojo extends AbstractMojo {
+	@Parameter(defaultValue = "${project}", required = true, readonly = true)
+	MavenProject project;
+
+	@Override
+	public void execute() throws MojoExecutionException	{
+	}
+}

--- a/maven-plugin/src/test/resources/plugin-test/pom.xml
+++ b/maven-plugin/src/test/resources/plugin-test/pom.xml
@@ -11,9 +11,17 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.github.alien.roseau</groupId>
+                <groupId>io.github.alien-tools</groupId>
                 <artifactId>roseau-maven-plugin</artifactId>
                 <version>0.2.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/maven-plugin/src/test/resources/plugin-test/pom.xml
+++ b/maven-plugin/src/test/resources/plugin-test/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.alien-tools</groupId>
+    <artifactId>roseau-plugin-test</artifactId>
+    <version>0.1.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.alien.roseau</groupId>
+                <artifactId>roseau-maven-plugin</artifactId>
+                <version>0.2.0-SNAPSHOT</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>core</module>
         <module>cli</module>
+        <module>maven-plugin</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Brainstorming ideas for the future Maven plug-in, with a first rough draft implementation.

## Features
- [X] Basic plug-in infrastructure
- [X] Fail the build on either source or binary incompatibilities
- [X] Make the plug-in skippable
- [X] Check the current version against a published version retrieved from remote repositories:
```
<oldVersion>
  <groupId>[...]</groupId>
  <aritfactId>[...]</aritfactId>
  <version>[...]</version>
</oldVersion>
```
- [ ] Check the current version against the *latest* published major/minor/patch version, without having to specify its coordinates
- [ ] Check the current version against a locally stored JSON API file, e.g., `<apiJson>latest-api.json</apiJson>`
- [ ] Write a report somewhere in `target/`
- [ ] Tests (Maven's plug-in test harness is 10 years old and I can't find a way to make it work)
- [ ] Documentation

## Usage
Manual invocation:
```
$ mvn roseau:check
```

Basic `pom.xml` configuration. Here, attaching to the `verify` phase when building `commons-cli`:
```
<plugin>
	<groupId>io.github.alien-tools</groupId>
	<artifactId>roseau-maven-plugin</artifactId>
	<version>0.2.0-SNAPSHOT</version>
	<configuration>
		<oldVersion>
			<groupId>commons-cli</groupId>
			<artifactId>commons-cli</artifactId>
			<version>1.0</version>
		</oldVersion>
	</configuration>
	<executions>
		<execution>
			<phase>verify</phase>
			<goals>
				<goal>check</goal>
			</goals>
		</execution>
	</executions>
</plugin>
```

## Implementation
We can assume that we have a JAR readily available that's just been built in the `package` phase. I don't see a reason to parse and analyze sources, so the implementation just uses [the ASM extractor](https://github.com/alien-tools/roseau/blob/main/core/src/main/java/io/github/alien/roseau/extractors/asm/AsmAPIExtractor.java).