### PR TITLE
Pass user classpath to reflective TypeProvider to enable resolution of external references

### DIFF
--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -93,7 +93,7 @@ public final class RoseauCLI implements Callable<Integer> {
 
 		if (extractor.canExtract(sources)) {
 			Stopwatch sw = Stopwatch.createStarted();
-			API api = extractor.extractTypes(sources, classpath).toAPI();
+			API api = extractor.extractTypes(sources, classpath).toAPI(classpath);
 			LOGGER.debug("Extracting API from sources {} using {} took {}ms ({} types)",
 				sources, extractor.getName(), sw.elapsed().toMillis(), api.getExportedTypes().size());
 			return api;

--- a/core/src/main/java/io/github/alien/roseau/api/model/LibraryTypes.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/LibraryTypes.java
@@ -67,14 +67,23 @@ public final class LibraryTypes implements TypeProvider {
 	}
 
 	/**
+	 * Creates a new resolved API using the given classpath and a default resolver.
+	 *
+	 * @param classpath the classpath used for type resolution
+	 * @return the new resolved API
+	 */
+	public API toAPI(List<Path> classpath) {
+		TypeProvider reflectiveTypeProvider = new SpoonTypeProvider(new CachingTypeReferenceFactory(), classpath);
+		return toAPI(new CachingTypeResolver(List.of(this, reflectiveTypeProvider)));
+	}
+
+	/**
 	 * Convenience method to create a resolved API using a default resolver.
 	 *
 	 * @return the new resolved API
 	 */
 	public API toAPI() {
-		// FIXME: this is just temporary
-		TypeProvider reflectiveTypeProvider = new SpoonTypeProvider(new CachingTypeReferenceFactory(), List.of());
-		return new API(this, new CachingTypeResolver(List.of(this, reflectiveTypeProvider)));
+		return toAPI(List.of());
 	}
 
 	/**

--- a/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
@@ -47,6 +47,7 @@ import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtWildcardReference;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,11 +71,21 @@ public class SpoonAPIFactory {
 	public SpoonAPIFactory(TypeReferenceFactory typeReferenceFactory, List<Path> classpath) {
 		Factory spoonFactory = new Launcher().createFactory();
 		spoonFactory.getEnvironment().setSourceClasspath(
-			classpath.stream()
+			sanitizeClasspath(classpath).stream()
 				.map(p -> p.toAbsolutePath().toString())
 				.toArray(String[]::new));
 		this.typeFactory = spoonFactory.Type();
 		this.typeReferenceFactory = typeReferenceFactory;
+	}
+
+	// Avoid having Spoon throwing at us due to "invalid" classpath
+	private List<Path> sanitizeClasspath(List<Path> classpath) {
+		return classpath.stream()
+			.map(Path::toFile)
+			.filter(File::exists)
+			.filter(f -> f.isDirectory() || !f.getName().endsWith(".class"))
+			.map(File::toPath)
+			.toList();
 	}
 
 	private ITypeReference createITypeReference(CtTypeReference<?> typeRef) {


### PR DESCRIPTION
The user classpath is necessary both at parsing and API construction times.