### PR TITLE
Unify sealable and permitted subtypes in API model

### DIFF
--- a/combinatorial/src/main/java/io/github/alien/roseau/combinatorial/api/CombinatorialApi.java
+++ b/combinatorial/src/main/java/io/github/alien/roseau/combinatorial/api/CombinatorialApi.java
@@ -396,7 +396,7 @@ public final class CombinatorialApi {
 						addConstructorToClassBuilder(clsBuilder, PUBLIC, List.of(), List.of(), false);
 
 						if (superCls.isSealed()) {
-							superClsBuilder.permittedTypes.add(clsBuilder.qualifiedName);
+							superClsBuilder.permittedTypes.add(typeReferenceFactory.createTypeReference(clsBuilder.qualifiedName));
 						}
 
 						if (isHidingAndOverriding) {
@@ -435,7 +435,7 @@ public final class CombinatorialApi {
 							}
 
 							if (implementingIntf.isSealed()) {
-								implementingIntfBuilder.permittedTypes.add(clsBuilder.qualifiedName);
+								implementingIntfBuilder.permittedTypes.add(typeReferenceFactory.createTypeReference(clsBuilder.qualifiedName));
 							}
 						});
 
@@ -580,7 +580,7 @@ public final class CombinatorialApi {
 			}
 
 			if (implementingIntf.isSealed()) {
-				implementingIntfBuilder.permittedTypes.add(builder.qualifiedName);
+				implementingIntfBuilder.permittedTypes.add(typeReferenceFactory.createTypeReference(builder.qualifiedName));
 			}
 		});
 	}

--- a/combinatorial/src/main/java/io/github/alien/roseau/combinatorial/builder/ClassBuilder.java
+++ b/combinatorial/src/main/java/io/github/alien/roseau/combinatorial/builder/ClassBuilder.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.combinatorial.builder;
 
 import io.github.alien.roseau.api.model.ClassDecl;
+import io.github.alien.roseau.api.model.TypeDecl;
 import io.github.alien.roseau.api.model.reference.TypeReference;
 
 import java.util.ArrayList;
@@ -9,7 +10,7 @@ import java.util.List;
 public sealed class ClassBuilder extends TypeBuilder permits EnumBuilder, RecordBuilder {
 	public TypeReference<ClassDecl> superClass;
 	public List<ConstructorBuilder> constructors = new ArrayList<>();
-	public List<String> permittedTypes = new ArrayList<>();
+	public List<TypeReference<TypeDecl>> permittedTypes = new ArrayList<>();
 
 	public ClassDecl make() {
 		var fields = this.fields.stream().map(FieldBuilder::make).toList();

--- a/combinatorial/src/main/java/io/github/alien/roseau/combinatorial/builder/InterfaceBuilder.java
+++ b/combinatorial/src/main/java/io/github/alien/roseau/combinatorial/builder/InterfaceBuilder.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.combinatorial.builder;
 
 import io.github.alien.roseau.api.model.InterfaceDecl;
+import io.github.alien.roseau.api.model.TypeDecl;
+import io.github.alien.roseau.api.model.reference.TypeReference;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public final class InterfaceBuilder extends TypeBuilder {
-	public List<String> permittedTypes = new ArrayList<>();
+	public List<TypeReference<TypeDecl>> permittedTypes = new ArrayList<>();
 
 	public InterfaceDecl make() {
 		var fields = this.fields.stream().map(FieldBuilder::make).toList();

--- a/core/src/main/java/io/github/alien/roseau/api/model/ClassDecl.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/ClassDecl.java
@@ -9,19 +9,19 @@ import java.util.Set;
 
 /**
  * A class declaration is a {@link TypeDecl} with an optional superclass and a list of {@link ConstructorDecl}.
- * {@link ClassDecl} instantiated without superclass implicitly extend {@link java.lang.Object}.
+ * {@link ClassDecl} instantiated without a superclass implicitly extend {@link java.lang.Object}.
  */
-public sealed class ClassDecl extends TypeDecl implements ISealableTypeDecl permits RecordDecl, EnumDecl {
+public sealed class ClassDecl extends TypeDecl permits RecordDecl, EnumDecl {
 	protected final TypeReference<ClassDecl> superClass;
 	protected final List<ConstructorDecl> constructors;
-	private final List<String> permittedTypes;
+	private final List<TypeReference<TypeDecl>> permittedTypes;
 
 	public ClassDecl(String qualifiedName, AccessModifier visibility, Set<Modifier> modifiers,
 	                 List<Annotation> annotations, SourceLocation location,
 	                 List<TypeReference<InterfaceDecl>> implementedInterfaces,
 	                 List<FormalTypeParameter> formalTypeParameters, List<FieldDecl> fields, List<MethodDecl> methods,
 	                 TypeReference<TypeDecl> enclosingType, TypeReference<ClassDecl> superClass,
-	                 List<ConstructorDecl> constructors, List<String> permittedTypes) {
+	                 List<ConstructorDecl> constructors, List<TypeReference<TypeDecl>> permittedTypes) {
 		super(qualifiedName, visibility, modifiers, annotations, location,
 			implementedInterfaces, formalTypeParameters, fields, methods, enclosingType);
 		Preconditions.checkNotNull(constructors);
@@ -54,8 +54,7 @@ public sealed class ClassDecl extends TypeDecl implements ISealableTypeDecl perm
 		return constructors;
 	}
 
-	@Override
-	public List<String> getPermittedTypes() {
+	public List<TypeReference<TypeDecl>> getPermittedTypes() {
 		return permittedTypes;
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/api/model/ClassDecl.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/ClassDecl.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public sealed class ClassDecl extends TypeDecl permits RecordDecl, EnumDecl {
 	protected final TypeReference<ClassDecl> superClass;
 	protected final List<ConstructorDecl> constructors;
-	private final List<TypeReference<TypeDecl>> permittedTypes;
+	protected final List<TypeReference<TypeDecl>> permittedTypes;
 
 	public ClassDecl(String qualifiedName, AccessModifier visibility, Set<Modifier> modifiers,
 	                 List<Annotation> annotations, SourceLocation location,

--- a/core/src/main/java/io/github/alien/roseau/api/model/ISealableTypeDecl.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/ISealableTypeDecl.java
@@ -1,8 +1,0 @@
-package io.github.alien.roseau.api.model;
-
-import java.util.List;
-
-public sealed interface ISealableTypeDecl permits ClassDecl, InterfaceDecl {
-	// Just duplicating the simpleName of permitted types CtSealable for now, but we should probably refactor this
-	List<String> getPermittedTypes();
-}

--- a/core/src/main/java/io/github/alien/roseau/api/model/InterfaceDecl.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/InterfaceDecl.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * An interface declaration in an {@link LibraryTypes}.
  */
 public final class InterfaceDecl extends TypeDecl {
-	private final List<TypeReference<TypeDecl>> permittedTypes;
+	protected final List<TypeReference<TypeDecl>> permittedTypes;
 
 	public InterfaceDecl(String qualifiedName, AccessModifier visibility, Set<Modifier> modifiers,
 	                     List<Annotation> annotations, SourceLocation location,

--- a/core/src/main/java/io/github/alien/roseau/api/model/InterfaceDecl.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/InterfaceDecl.java
@@ -10,14 +10,14 @@ import java.util.Set;
 /**
  * An interface declaration in an {@link LibraryTypes}.
  */
-public final class InterfaceDecl extends TypeDecl implements ISealableTypeDecl {
-	private final List<String> permittedTypes;
+public final class InterfaceDecl extends TypeDecl {
+	private final List<TypeReference<TypeDecl>> permittedTypes;
 
 	public InterfaceDecl(String qualifiedName, AccessModifier visibility, Set<Modifier> modifiers,
 	                     List<Annotation> annotations, SourceLocation location,
 	                     List<TypeReference<InterfaceDecl>> implementedInterfaces,
 	                     List<FormalTypeParameter> formalTypeParameters, List<FieldDecl> fields, List<MethodDecl> methods,
-	                     TypeReference<TypeDecl> enclosingType, List<String> permittedTypes) {
+	                     TypeReference<TypeDecl> enclosingType, List<TypeReference<TypeDecl>> permittedTypes) {
 		super(qualifiedName, visibility, modifiers, annotations, location, implementedInterfaces, formalTypeParameters,
 			fields, methods, enclosingType);
 		Preconditions.checkNotNull(permittedTypes);
@@ -29,8 +29,7 @@ public final class InterfaceDecl extends TypeDecl implements ISealableTypeDecl {
 		return true;
 	}
 
-	@Override
-	public List<String> getPermittedTypes() {
+	public List<TypeReference<TypeDecl>> getPermittedTypes() {
 		return permittedTypes;
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/api/visit/APIAlgebra.java
+++ b/core/src/main/java/io/github/alien/roseau/api/visit/APIAlgebra.java
@@ -63,16 +63,16 @@ public interface APIAlgebra<T> {
 
 	default T $(Symbol it) {
 		return switch (it) {
-			case RecordDecl r      -> recordDecl(r);
-			case EnumDecl e        -> enumDecl(e);
-			case ClassDecl c       -> classDecl(c);
-			case InterfaceDecl i   -> interfaceDecl(i);
-			case AnnotationDecl a  -> annotationDecl(a);
-			case MethodDecl m      -> methodDecl(m);
-			case ConstructorDecl c -> constructorDecl(c);
-			case EnumValueDecl eV -> enumValueDecl(eV);
-			case RecordComponentDecl rC -> recordComponentDecl(rC);
-			case FieldDecl f       -> fieldDecl(f);
+			case RecordDecl r          -> recordDecl(r);
+			case EnumDecl e            -> enumDecl(e);
+			case ClassDecl c           -> classDecl(c);
+			case InterfaceDecl i       -> interfaceDecl(i);
+			case AnnotationDecl a      -> annotationDecl(a);
+			case MethodDecl m          -> methodDecl(m);
+			case ConstructorDecl c     -> constructorDecl(c);
+			case EnumValueDecl v       -> enumValueDecl(v);
+			case RecordComponentDecl c -> recordComponentDecl(c);
+			case FieldDecl f           -> fieldDecl(f);
 		};
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/api/visit/APIPrettyPrinter.java
+++ b/core/src/main/java/io/github/alien/roseau/api/visit/APIPrettyPrinter.java
@@ -70,7 +70,7 @@ public class APIPrettyPrinter implements APIAlgebra<Print> {
 				: "implements " + it.getImplementedInterfaces().stream().map(TypeReference::getQualifiedName).collect(Collectors.joining(", ")),
 			it.getPermittedTypes().isEmpty()
 				? ""
-				: "permits " + String.join(", ", it.getPermittedTypes()),
+				: "permits " + it.getPermittedTypes().stream().map(TypeReference::getQualifiedName).collect(Collectors.joining(", ")),
 			it.getDeclaredFields().stream().map(f -> $(f).print()).collect(Collectors.joining("\n")),
 			it.getDeclaredConstructors().stream().map(cons -> $(cons).print()).collect(Collectors.joining("\n")),
 			it.getDeclaredMethods().stream().map(m -> $(m).print()).collect(Collectors.joining("\n"))
@@ -96,7 +96,7 @@ public class APIPrettyPrinter implements APIAlgebra<Print> {
 				: "extends " + it.getImplementedInterfaces().stream().map(TypeReference::getQualifiedName).collect(Collectors.joining(", ")),
 			it.getPermittedTypes().isEmpty()
 				? ""
-				: "permits " + String.join(", ", it.getPermittedTypes()),
+				: "permits " + it.getPermittedTypes().stream().map(TypeReference::getQualifiedName).collect(Collectors.joining(", ")),
 			it.getDeclaredFields().stream().map(f -> $(f).print()).collect(Collectors.joining("\n")),
 			it.getDeclaredMethods().stream().map(m -> $(m).print()).collect(Collectors.joining("\n"))
 		);

--- a/core/src/main/java/io/github/alien/roseau/api/visit/AbstractAPIVisitor.java
+++ b/core/src/main/java/io/github/alien/roseau/api/visit/AbstractAPIVisitor.java
@@ -24,7 +24,6 @@ import io.github.alien.roseau.api.model.reference.PrimitiveTypeReference;
 import io.github.alien.roseau.api.model.reference.TypeParameterReference;
 import io.github.alien.roseau.api.model.reference.TypeReference;
 import io.github.alien.roseau.api.model.reference.WildcardTypeReference;
-import org.xmlet.htmlapifaster.U;
 
 /**
  * A default abstract implementation of {@link APIAlgebra} using {@link Visit} as the lambda type that produces no

--- a/core/src/main/java/io/github/alien/roseau/api/visit/AbstractAPIVisitor.java
+++ b/core/src/main/java/io/github/alien/roseau/api/visit/AbstractAPIVisitor.java
@@ -1,7 +1,6 @@
 package io.github.alien.roseau.api.visit;
 
 import io.github.alien.roseau.api.model.API;
-import io.github.alien.roseau.api.model.LibraryTypes;
 import io.github.alien.roseau.api.model.Annotation;
 import io.github.alien.roseau.api.model.AnnotationDecl;
 import io.github.alien.roseau.api.model.ClassDecl;
@@ -12,6 +11,7 @@ import io.github.alien.roseau.api.model.ExecutableDecl;
 import io.github.alien.roseau.api.model.FieldDecl;
 import io.github.alien.roseau.api.model.FormalTypeParameter;
 import io.github.alien.roseau.api.model.InterfaceDecl;
+import io.github.alien.roseau.api.model.LibraryTypes;
 import io.github.alien.roseau.api.model.MethodDecl;
 import io.github.alien.roseau.api.model.ParameterDecl;
 import io.github.alien.roseau.api.model.RecordComponentDecl;
@@ -24,6 +24,7 @@ import io.github.alien.roseau.api.model.reference.PrimitiveTypeReference;
 import io.github.alien.roseau.api.model.reference.TypeParameterReference;
 import io.github.alien.roseau.api.model.reference.TypeReference;
 import io.github.alien.roseau.api.model.reference.WildcardTypeReference;
+import org.xmlet.htmlapifaster.U;
 
 /**
  * A default abstract implementation of {@link APIAlgebra} using {@link Visit} as the lambda type that produces no
@@ -35,12 +36,6 @@ public abstract class AbstractAPIVisitor implements APIAlgebra<Visit> {
 		return () -> $(it.getLibraryTypes()).visit();
 	}
 
-	/**
-	 * Visits the given {@link LibraryTypes}.
-	 *
-	 * @param it the {@link LibraryTypes} to visit
-	 * @return a lambda {@link Visit} that must be invoked to run the actual visit
-	 */
 	@Override
 	public Visit libraryTypes(LibraryTypes it) {
 		return () -> it.getAllTypes().forEach(t -> $(t).visit());
@@ -51,13 +46,17 @@ public abstract class AbstractAPIVisitor implements APIAlgebra<Visit> {
 		return () -> {
 			typeDecl(it).visit();
 			$(it.getSuperClass()).visit();
+			it.getPermittedTypes().forEach(t -> $(t).visit());
 			it.getDeclaredConstructors().forEach(cons -> $(cons).visit());
 		};
 	}
 
 	@Override
 	public Visit interfaceDecl(InterfaceDecl it) {
-		return typeDecl(it);
+		return () -> {
+			typeDecl(it).visit();
+			it.getPermittedTypes().forEach(t -> $(t).visit());
+		};
 	}
 
 	@Override

--- a/core/src/main/java/io/github/alien/roseau/extractors/jdt/JdtAPIVisitor.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/jdt/JdtAPIVisitor.java
@@ -200,11 +200,11 @@ final class JdtAPIVisitor extends ASTVisitor {
 		TypeDecl typeDecl = switch (type) {
 			case TypeDeclaration c when !c.isInterface() ->
 				new ClassDecl(qualifiedName, visibility, modifiers, annotations, location, implementedInterfaces,
-					typeParams, fields, methods, enclosingType, superClassRef, constructors, List.of());
+					typeParams, fields, methods, enclosingType, superClassRef, constructors, convertPermittedTypes(c));
 			case TypeDeclaration i when i.isInterface() -> {
 				modifiers.add(Modifier.ABSTRACT);
 				yield new InterfaceDecl(qualifiedName, visibility, modifiers, annotations, location, implementedInterfaces,
-					typeParams, fields, methods, enclosingType, List.of());
+					typeParams, fields, methods, enclosingType, convertPermittedTypes(i));
 			}
 			case EnumDeclaration e ->
 				new EnumDecl(qualifiedName, visibility, modifiers, annotations, location, implementedInterfaces,
@@ -326,6 +326,12 @@ final class JdtAPIVisitor extends ASTVisitor {
 		return Arrays.stream(typeParameters)
 			.map(tp -> new FormalTypeParameter(tp.getName(),
 				Arrays.stream(tp.getTypeBounds()).map(this::makeTypeReference).toList()))
+			.toList();
+	}
+
+	private List<TypeReference<TypeDecl>> convertPermittedTypes(TypeDeclaration type) {
+		return ((List<org.eclipse.jdt.core.dom.Type>) type.permittedTypes()).stream()
+			.map(t -> typeRefFactory.createTypeReference(t.resolveBinding().getQualifiedName()))
 			.toList();
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
@@ -389,9 +389,9 @@ public class SpoonAPIFactory {
 			: new ParameterDecl(parameter.getSimpleName(), createITypeReference(parameter.getType()), false);
 	}
 
-	private List<String> convertCtSealable(CtSealable sealable) {
+	private List<TypeReference<TypeDecl>> convertCtSealable(CtSealable sealable) {
 		return sealable.getPermittedTypes().stream()
-			.map(CtTypeReference::getSimpleName)
+			.map(this::createTypeReference)
 			.toList();
 	}
 


### PR DESCRIPTION
Properly type permitted subtypes as `TypeReference<TypeDecl>` and populate those from ASM, JDT, and Spoon. Test the extractors.

ASM <= 9 does not provide first-class support for `sealed`/`non-sealed`, so there's no reliable way of extracting this information. We consider any type with permitted types to be `sealed`, but this misses `sealed` types with implicit nested permitted types. No reliable heuristic for `non-sealed` so this isn't inferred. Spoon and JDT are fine.