### PR TITLE
Improve BCs reporting

### DIFF
--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -8,7 +8,6 @@ import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.APIDiff;
 import io.github.alien.roseau.diff.RoseauReport;
 import io.github.alien.roseau.diff.changes.BreakingChange;
-import io.github.alien.roseau.diff.changes.BreakingChangeDetails;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatter;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatterFactory;
 import io.github.alien.roseau.diff.formatter.CliFormatter;
@@ -27,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -165,28 +163,6 @@ public final class RoseauCLI implements Callable<Integer> {
 		}
 	}
 
-	/*private String format(BreakingChange bc) {
-		String details = switch (bc.details()) {
-			case BreakingChangeDetails.None d -> "";
-			case BreakingChangeDetails.MethodReturnTypeChanged(var oldType, var newType) ->
-				"old: %s, new: %s".formatted(oldType, newType);
-			case BreakingChangeDetails.MethodAddedToInterface(var newMethod) -> "method: " + newMethod.getSignature();
-			case BreakingChangeDetails.MethodAbstractAddedToClass(var newMethod) -> "method: " + newMethod.getSignature();
-		};
-
-		if (plain) {
-			return String.format("%s %s%s%n\t%s:%s", bc.kind(), bc.impactedSymbol().getQualifiedName(),
-				details.isEmpty() ? "" : " [%s]".formatted(details),
-				bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
-		} else {
-			return String.format("%s %s%s%n\t%s:%s",
-				RED_TEXT + BOLD + bc.kind() + RESET,
-				UNDERLINE + bc.impactedSymbol().getQualifiedName() + RESET,
-				details.isEmpty() ? "" : " [%s]".formatted(details),
-				bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
-		}
-	}*/
-
 	private void checkArguments() {
 		if (v1 == null || !Files.exists(v1)) {
 			throw new IllegalArgumentException("--v1 does not exist");
@@ -238,7 +214,7 @@ public final class RoseauCLI implements Callable<Integer> {
 				if (bcs.isEmpty()) {
 					System.out.println("No breaking changes found.");
 				} else {
-					System.out.println(new CliFormatter().format(report));
+					System.out.println(new CliFormatter(plain).format(report));
 				}
 
 				if (failMode && !bcs.isEmpty()) {

--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -11,6 +11,7 @@ import io.github.alien.roseau.diff.changes.BreakingChange;
 import io.github.alien.roseau.diff.changes.BreakingChangeDetails;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatter;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatterFactory;
+import io.github.alien.roseau.diff.formatter.CliFormatter;
 import io.github.alien.roseau.extractors.ExtractorType;
 import io.github.alien.roseau.extractors.MavenClasspathBuilder;
 import io.github.alien.roseau.extractors.TypesExtractor;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 /**
  * Main class implementing a CLI for interacting with Roseau. See {@code --help} for usage information.
@@ -82,10 +82,6 @@ public final class RoseauCLI implements Callable<Integer> {
 	private boolean plain;
 
 	private static final Logger LOGGER = LogManager.getLogger(RoseauCLI.class);
-	private static final String RED_TEXT = "\u001B[31m";
-	private static final String BOLD = "\u001B[1m";
-	private static final String UNDERLINE = "\u001B[4m";
-	private static final String RESET = "\u001B[0m";
 
 	private API buildAPI(Library library) {
 		TypesExtractor extractor = library.getExtractorType().newExtractor();
@@ -119,7 +115,7 @@ public final class RoseauCLI implements Callable<Integer> {
 			LOGGER.debug("API diff took {}ms ({} breaking changes)",
 				sw.elapsed().toMillis(), report.breakingChanges().size());
 
-			writeReport(apiV1, report);
+			writeReport(report);
 			return report;
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
@@ -128,7 +124,7 @@ public final class RoseauCLI implements Callable<Integer> {
 			LOGGER.error("Couldn't compute diff", e);
 		}
 
-		return new RoseauReport(libraryV1, libraryV2, Collections.emptyList());
+		return null; // FIXME
 	}
 
 	private List<Path> buildClasspath() {
@@ -155,22 +151,22 @@ public final class RoseauCLI implements Callable<Integer> {
 		return classpath;
 	}
 
-	private void writeReport(API api, RoseauReport report) {
+	private void writeReport(RoseauReport report) {
 		if (reportPath == null)
 			return;
 
 		BreakingChangesFormatter fmt = BreakingChangesFormatterFactory.newBreakingChangesFormatter(format);
 
 		try {
-			Files.writeString(reportPath, fmt.format(api, report));
+			Files.writeString(reportPath, fmt.format(report));
 			LOGGER.info("Wrote report to {}", reportPath);
 		} catch (IOException e) {
 			LOGGER.error("Couldn't write report to {}", reportPath, e);
 		}
 	}
 
-	private String format(BreakingChange bc) {
-		String details = switch(bc.details()) {
+	/*private String format(BreakingChange bc) {
+		String details = switch (bc.details()) {
 			case BreakingChangeDetails.None d -> "";
 			case BreakingChangeDetails.MethodReturnTypeChanged(var oldType, var newType) ->
 				"old: %s, new: %s".formatted(oldType, newType);
@@ -189,7 +185,7 @@ public final class RoseauCLI implements Callable<Integer> {
 				details.isEmpty() ? "" : " [%s]".formatted(details),
 				bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
 		}
-	}
+	}*/
 
 	private void checkArguments() {
 		if (v1 == null || !Files.exists(v1)) {
@@ -236,16 +232,13 @@ public final class RoseauCLI implements Callable<Integer> {
 					builder2.extractorType(extractorType);
 				}
 				Library libraryV2 = builder2.build();
-				List<BreakingChange> bcs = diff(libraryV1, libraryV2).breakingChanges();
+				RoseauReport report = diff(libraryV1, libraryV2);
+				List<BreakingChange> bcs = report.breakingChanges();
 
 				if (bcs.isEmpty()) {
 					System.out.println("No breaking changes found.");
 				} else {
-					System.out.println(
-						bcs.stream()
-							.map(this::format)
-							.collect(Collectors.joining(System.lineSeparator()))
-					);
+					System.out.println(new CliFormatter().format(report));
 				}
 
 				if (failMode && !bcs.isEmpty()) {

--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -8,6 +8,7 @@ import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.APIDiff;
 import io.github.alien.roseau.diff.RoseauReport;
 import io.github.alien.roseau.diff.changes.BreakingChange;
+import io.github.alien.roseau.diff.changes.BreakingChangeDetails;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatter;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatterFactory;
 import io.github.alien.roseau.extractors.ExtractorType;
@@ -169,13 +170,23 @@ public final class RoseauCLI implements Callable<Integer> {
 	}
 
 	private String format(BreakingChange bc) {
+		String details = switch(bc.details()) {
+			case BreakingChangeDetails.None d -> "";
+			case BreakingChangeDetails.MethodReturnTypeChanged(var oldType, var newType) ->
+				"old: %s, new: %s".formatted(oldType, newType);
+			case BreakingChangeDetails.MethodAddedToInterface(var newMethod) -> "method: " + newMethod.getSignature();
+			case BreakingChangeDetails.MethodAbstractAddedToClass(var newMethod) -> "method: " + newMethod.getSignature();
+		};
+
 		if (plain) {
-			return String.format("%s %s%n\t%s:%s", bc.kind(), bc.impactedSymbol().getQualifiedName(),
+			return String.format("%s %s%s%n\t%s:%s", bc.kind(), bc.impactedSymbol().getQualifiedName(),
+				details.isEmpty() ? "" : " [%s]".formatted(details),
 				bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
 		} else {
-			return String.format("%s %s%n\t%s:%s",
+			return String.format("%s %s%s%n\t%s:%s",
 				RED_TEXT + BOLD + bc.kind() + RESET,
 				UNDERLINE + bc.impactedSymbol().getQualifiedName() + RESET,
+				details.isEmpty() ? "" : " [%s]".formatted(details),
 				bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
 		}
 	}

--- a/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
@@ -76,7 +76,7 @@ public class APIDiff {
 			)
 		);
 
-		return new RoseauReport(v1.getLibraryTypes().getLibrary(), v2.getLibraryTypes().getLibrary(), getBreakingChanges());
+		return new RoseauReport(v1, v2, getBreakingChanges());
 	}
 
 	private void diffFields(TypeDecl t1, TypeDecl t2) {

--- a/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
@@ -413,7 +413,8 @@ public class APIDiff {
 
 				if (e1.isMethod()) { // Invariant
 					if (!new HashSet<>(bounds1).equals(new HashSet<>(bounds2))) {
-						bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_CHANGED, e1, e2);
+						bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_CHANGED, e1, e2,
+							new BreakingChangeDetails.MethodFormalTypeParametersChanged(ftp1, ftp2));
 					}
 				} else { // Variance
 					// Any new bound that's not a supertype of an existing bound is breaking

--- a/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
@@ -16,6 +16,7 @@ import io.github.alien.roseau.api.model.TypeDecl;
 import io.github.alien.roseau.api.model.reference.ITypeReference;
 import io.github.alien.roseau.api.model.reference.TypeReference;
 import io.github.alien.roseau.diff.changes.BreakingChange;
+import io.github.alien.roseau.diff.changes.BreakingChangeDetails;
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
 
 import java.util.HashSet;
@@ -117,11 +118,11 @@ public class APIDiff {
 			.filter(m2 -> v1.getAllMethods(t1).stream().noneMatch(m1 -> v1.haveSameErasure(m1, m2)))
 			.forEach(m2 -> {
 				if (t1.isInterface()) {
-					bc(BreakingChangeKind.METHOD_ADDED_TO_INTERFACE, t1, m2);
+					bc(BreakingChangeKind.METHOD_ADDED_TO_INTERFACE, t1, t2, new BreakingChangeDetails.MethodAddedToInterface(m2));
 				}
 
 				if (t1.isClass()) {
-					bc(BreakingChangeKind.METHOD_ABSTRACT_ADDED_TO_CLASS, t1, m2);
+					bc(BreakingChangeKind.METHOD_ABSTRACT_ADDED_TO_CLASS, t1, t2, new BreakingChangeDetails.MethodAbstractAddedToClass(m2));
 				}
 			});
 	}
@@ -209,7 +210,7 @@ public class APIDiff {
 		a2.getAnnotationMethods().stream()
 			.filter(m2 -> !m2.hasDefault())
 			.filter(m2 -> a1.getAnnotationMethods().stream().noneMatch(m1 -> m1.getSimpleName().equals(m2.getSimpleName())))
-			.forEach(m2 -> bc(BreakingChangeKind.ANNOTATION_METHOD_ADDED_WITHOUT_DEFAULT, a1, m2));
+			.forEach(m2 -> bc(BreakingChangeKind.ANNOTATION_METHOD_ADDED_WITHOUT_DEFAULT, a1, a2));
 	}
 
 	private void diffField(FieldDecl f1, FieldDecl f2) {
@@ -256,7 +257,8 @@ public class APIDiff {
 		}
 
 		if (!m1.getType().equals(m2.getType())) {
-			bc(BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, m1, m2);
+			bc(BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, m1, m2,
+				new BreakingChangeDetails.MethodReturnTypeChanged(m1.getType(), m2.getType()));
 		}
 
 		diffThrownExceptions(m1, m2);
@@ -393,7 +395,11 @@ public class APIDiff {
 	}
 
 	private void bc(BreakingChangeKind kind, Symbol impactedSymbol, Symbol newSymbol) {
-		BreakingChange bc = new BreakingChange(kind, impactedSymbol, newSymbol);
+		bc(kind, impactedSymbol, newSymbol, new BreakingChangeDetails.None());
+	}
+
+	private void bc(BreakingChangeKind kind, Symbol impactedSymbol, Symbol newSymbol, BreakingChangeDetails details) {
+		BreakingChange bc = new BreakingChange(kind, impactedSymbol, newSymbol, details);
 		breakingChanges.add(bc);
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
@@ -289,16 +289,17 @@ public class APIDiff {
 	}
 
 	private void diffThrownExceptions(ExecutableDecl e1, ExecutableDecl e2) {
-		v1.getThrownCheckedExceptions(e1).stream()
-			.filter(exc1 -> v2.getThrownCheckedExceptions(e2).stream()
-				.noneMatch(exc2 -> v2.isSubtypeOf(exc2, exc1)))
+		List<ITypeReference> thrown1 = v1.getThrownCheckedExceptions(e1);
+		List<ITypeReference> thrown2 = v2.getThrownCheckedExceptions(e2);
+
+		thrown1.stream()
+			.filter(exc1 -> thrown2.stream().noneMatch(exc2 -> v2.isSubtypeOf(exc2, exc1)))
 			.forEach(exc1 ->
 				bc(BreakingChangeKind.METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION, e1, e2,
 					new BreakingChangeDetails.MethodNoLongerThrowsCheckedException(exc1)));
 
-		v2.getThrownCheckedExceptions(e2).stream()
-			.filter(exc2 -> v1.getThrownCheckedExceptions(e1).stream()
-				.noneMatch(exc1 -> v2.isSubtypeOf(exc2, exc1)))
+		thrown2.stream()
+			.filter(exc2 -> thrown1.stream().noneMatch(exc1 -> v2.isSubtypeOf(exc2, exc1)))
 			.forEach(exc2 ->
 				bc(BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, e1, e2,
 					new BreakingChangeDetails.MethodNowThrowsCheckedException(exc2)));

--- a/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
@@ -1,5 +1,6 @@
 package io.github.alien.roseau.diff;
 
+import com.google.common.collect.Sets;
 import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.api.model.AnnotationDecl;
 import io.github.alien.roseau.api.model.AnnotationMethodDecl;
@@ -115,14 +116,17 @@ public class APIDiff {
 	private void diffAddedMethods(TypeDecl t1, TypeDecl t2) {
 		v2.getAllMethods(t2).stream()
 			.filter(MethodDecl::isAbstract)
-			.filter(m2 -> v1.getAllMethods(t1).stream().noneMatch(m1 -> v1.haveSameErasure(m1, m2)))
+			.filter(m2 -> v1.getAllMethods(t1).stream()
+				.noneMatch(m1 -> v1.haveSameErasure(m1, m2)))
 			.forEach(m2 -> {
 				if (t1.isInterface()) {
-					bc(BreakingChangeKind.METHOD_ADDED_TO_INTERFACE, t1, t2, new BreakingChangeDetails.MethodAddedToInterface(m2));
+					bc(BreakingChangeKind.METHOD_ADDED_TO_INTERFACE, t1, t2,
+						new BreakingChangeDetails.MethodAddedToInterface(m2));
 				}
 
 				if (t1.isClass()) {
-					bc(BreakingChangeKind.METHOD_ABSTRACT_ADDED_TO_CLASS, t1, t2, new BreakingChangeDetails.MethodAbstractAddedToClass(m2));
+					bc(BreakingChangeKind.METHOD_ABSTRACT_ADDED_TO_CLASS, t1, t2,
+						new BreakingChangeDetails.MethodAbstractAddedToClass(m2));
 				}
 			});
 	}
@@ -133,14 +137,16 @@ public class APIDiff {
 		}
 
 		if (!t1.getClass().equals(t2.getClass())) {
-			bc(BreakingChangeKind.CLASS_TYPE_CHANGED, t1, t2);
+			bc(BreakingChangeKind.CLASS_TYPE_CHANGED, t1, t2,
+				new BreakingChangeDetails.ClassTypeChanged(t1.getClass(), t2.getClass()));
 		}
 
 		// If a supertype that was exported has been removed,
 		// it may have been used in client code for casts
-		if (v1.getAllSuperTypes(t1).stream().anyMatch(sup -> v1.isExported(sup) && !v2.isSubtypeOf(t2, sup))) {
-			bc(BreakingChangeKind.SUPERTYPE_REMOVED, t1, t2);
-		}
+		v1.getAllSuperTypes(t1).stream()
+			.filter(sup -> v1.isExported(sup) && !v2.isSubtypeOf(t2, sup))
+			.forEach(sup -> bc(BreakingChangeKind.SUPERTYPE_REMOVED, t1, t2,
+				new BreakingChangeDetails.SuperTypeRemoved(sup)));
 
 		diffFields(t1, t2);
 		diffMethods(t1, t2);
@@ -165,12 +171,14 @@ public class APIDiff {
 			bc(BreakingChangeKind.CLASS_NOW_ABSTRACT, c1, c2);
 		}
 
-		if (!c1.isStatic() && c2.isStatic() && c1.isNested() && c2.isNested()) {
-			bc(BreakingChangeKind.NESTED_CLASS_NOW_STATIC, c1, c2);
-		}
+		if (c1.isNested() && c2.isNested()) {
+			if (!c1.isStatic() && c2.isStatic()) {
+				bc(BreakingChangeKind.NESTED_CLASS_NOW_STATIC, c1, c2);
+			}
 
-		if (c1.isStatic() && !c2.isStatic() && c1.isNested() && c2.isNested()) {
-			bc(BreakingChangeKind.NESTED_CLASS_NO_LONGER_STATIC, c1, c2);
+			if (c1.isStatic() && !c2.isStatic()) {
+				bc(BreakingChangeKind.NESTED_CLASS_NO_LONGER_STATIC, c1, c2);
+			}
 		}
 
 		if (v1.isUncheckedException(c1) && v2.isCheckedException(c2)) {
@@ -181,9 +189,10 @@ public class APIDiff {
 	}
 
 	private void diffAnnotationInterface(AnnotationDecl a1, AnnotationDecl a2) {
-		if (!a2.getTargets().containsAll(a1.getTargets())) {
-			bc(BreakingChangeKind.ANNOTATION_TARGET_REMOVED, a1, a2);
-		}
+		Sets.difference(a1.getTargets(), a2.getTargets()).forEach(target -> {
+			bc(BreakingChangeKind.ANNOTATION_TARGET_REMOVED, a1, a2,
+				new BreakingChangeDetails.AnnotationTargetRemoved(target));
+		});
 
 		if (a1.isRepeatable() && !a2.isRepeatable()) {
 			bc(BreakingChangeKind.ANNOTATION_NO_LONGER_REPEATABLE, a1, a2);
@@ -202,14 +211,16 @@ public class APIDiff {
 				}
 
 				if (!m1.getType().equals(m2.getType())) {
-					bc(BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, m1, m2);
+					bc(BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, m1, m2,
+						new BreakingChangeDetails.MethodReturnTypeChanged(m1.getType(), m2.getType()));
 				}
 			}, () -> bc(BreakingChangeKind.METHOD_REMOVED, m1, null));
 		});
 
 		a2.getAnnotationMethods().stream()
 			.filter(m2 -> !m2.hasDefault())
-			.filter(m2 -> a1.getAnnotationMethods().stream().noneMatch(m1 -> m1.getSimpleName().equals(m2.getSimpleName())))
+			.filter(m2 -> a1.getAnnotationMethods().stream()
+				.noneMatch(m1 -> m1.getSimpleName().equals(m2.getSimpleName())))
 			.forEach(m2 -> bc(BreakingChangeKind.ANNOTATION_METHOD_ADDED_WITHOUT_DEFAULT, a1, a2));
 	}
 
@@ -227,7 +238,8 @@ public class APIDiff {
 		}
 
 		if (!f1.getType().equals(f2.getType())) {
-			bc(BreakingChangeKind.FIELD_TYPE_CHANGED, f1, f2);
+			bc(BreakingChangeKind.FIELD_TYPE_CHANGED, f1, f2,
+				new BreakingChangeDetails.FieldTypeChanged(f1.getType(), f2.getType()));
 		}
 
 		if (f1.isPublic() && f2.isProtected()) {
@@ -277,19 +289,19 @@ public class APIDiff {
 	}
 
 	private void diffThrownExceptions(ExecutableDecl e1, ExecutableDecl e2) {
-		if (v1.getThrownCheckedExceptions(e1)
-			.stream()
-			.anyMatch(exc1 -> v2.getThrownCheckedExceptions(e2).stream()
-				.noneMatch(exc2 -> v2.isSubtypeOf(exc2, exc1)))) {
-			bc(BreakingChangeKind.METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION, e1, e2);
-		}
+		v1.getThrownCheckedExceptions(e1).stream()
+			.filter(exc1 -> v2.getThrownCheckedExceptions(e2).stream()
+				.noneMatch(exc2 -> v2.isSubtypeOf(exc2, exc1)))
+			.forEach(exc1 ->
+				bc(BreakingChangeKind.METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION, e1, e2,
+					new BreakingChangeDetails.MethodNoLongerThrowsCheckedException(exc1)));
 
-		if (v2.getThrownCheckedExceptions(e2)
-			.stream()
-			.anyMatch(exc2 -> v1.getThrownCheckedExceptions(e1).stream()
-				.noneMatch(exc1 -> v2.isSubtypeOf(exc2, exc1)))) {
-			bc(BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, e1, e2);
-		}
+		v2.getThrownCheckedExceptions(e2).stream()
+			.filter(exc2 -> v1.getThrownCheckedExceptions(e1).stream()
+				.noneMatch(exc1 -> v2.isSubtypeOf(exc2, exc1)))
+			.forEach(exc2 ->
+				bc(BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, e1, e2,
+					new BreakingChangeDetails.MethodNowThrowsCheckedException(exc2)));
 	}
 
 	private void diffParameters(ExecutableDecl e1, ExecutableDecl e2) {
@@ -299,7 +311,7 @@ public class APIDiff {
 			ParameterDecl p2 = e2.getParameters().get(i);
 
 			if (p1.type() instanceof TypeReference<?> t1 && p2.type() instanceof TypeReference<?> t2) {
-				diffParameterGenerics(e1, e2, t1, t2);
+				diffParameterGenerics(p1, e1, e2, t1, t2);
 			}
 		}
 	}
@@ -307,21 +319,26 @@ public class APIDiff {
 	/**
 	 * In general, we need to distinguish how formal type parameters and parameter generics are handled between methods
 	 * and constructors: the former can be overridden (thus parameters are immutable so that signatures in
-	 * sub/super-classes match) and the latter cannot (thus parameters can follow variance rules).
+	 * sub/super-classes match), and the latter cannot (thus parameters can follow variance rules).
 	 */
-	private void diffParameterGenerics(ExecutableDecl e1, ExecutableDecl e2, TypeReference<?> t1, TypeReference<?> t2) {
+	private void diffParameterGenerics(ParameterDecl p1,
+	                                   ExecutableDecl e1, ExecutableDecl e2,
+	                                   TypeReference<?> t1, TypeReference<?> t2) {
+		BreakingChangeDetails.MethodParameterGenericsChanged details =
+			new  BreakingChangeDetails.MethodParameterGenericsChanged(p1, t1, t2);
+
 		if (t1.typeArguments().size() != t2.typeArguments().size()) {
-			bc(BreakingChangeKind.METHOD_PARAMETER_GENERICS_CHANGED, e1, e2);
+			bc(BreakingChangeKind.METHOD_PARAMETER_GENERICS_CHANGED, e1, e2, details);
 			return;
 		}
 
 		// Should be invariant, but they're not equal
 		if (e1.isMethod() && !t1.equals(t2)) {
-			bc(BreakingChangeKind.METHOD_PARAMETER_GENERICS_CHANGED, e1, e2);
+			bc(BreakingChangeKind.METHOD_PARAMETER_GENERICS_CHANGED, e1, e2, details);
 		}
 
 		if (e1.isConstructor() && !v1.isSubtypeOf(t1, t2)) {
-			bc(BreakingChangeKind.METHOD_PARAMETER_GENERICS_CHANGED, e1, e2);
+			bc(BreakingChangeKind.METHOD_PARAMETER_GENERICS_CHANGED, e1, e2, details);
 		}
 	}
 
@@ -331,13 +348,19 @@ public class APIDiff {
 
 		// Removing formal type parameters always breaks
 		if (paramsCount1 > paramsCount2) {
-			bc(BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_REMOVED, t1, t2);
+			t1.getFormalTypeParameters().subList(paramsCount2, paramsCount1)
+				.forEach(ftp ->
+					bc(BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_REMOVED, t1, t2,
+						new BreakingChangeDetails.TypeFormalTypeParametersRemoved(ftp)));
 			return;
 		}
 
 		// Adding formal type parameters breaks unless it's the first
 		if (paramsCount2 > paramsCount1 && paramsCount1 > 0) {
-			bc(BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_ADDED, t1, t2);
+			t2.getFormalTypeParameters().subList(paramsCount1, paramsCount2)
+					.forEach(ftp ->
+						bc(BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_ADDED, t1, t2,
+							new BreakingChangeDetails.TypeFormalTypeParametersAdded(ftp)));
 			return;
 		}
 
@@ -345,12 +368,13 @@ public class APIDiff {
 			FormalTypeParameter p1 = t1.getFormalTypeParameters().get(i);
 			FormalTypeParameter p2 = t2.getFormalTypeParameters().get(i);
 
-			// Each bound in the new version should be a supertype of an existing one (or the same)
+			// Each bound in the new version should be a supertype (inclusive) of an existing one
 			// so that the type constraints imposed by p1 are stricter than those imposed by p2
 			if (p2.bounds().stream()
 				.anyMatch(b2 -> !b2.equals(TypeReference.OBJECT) &&
 					p1.bounds().stream().noneMatch(b1 -> v2.isSubtypeOf(b1, b2)))) {
-				bc(BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, t1, t2);
+				bc(BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, t1, t2,
+					new BreakingChangeDetails.TypeFormalTypeParametersChanged(p1, p2));
 			}
 		}
 	}
@@ -359,23 +383,33 @@ public class APIDiff {
 		int paramsCount1 = e1.getFormalTypeParameters().size();
 		int paramsCount2 = e2.getFormalTypeParameters().size();
 
-		// Ok, well. Removing a type parameter is breaking if:
+		// Removing a type parameter is breaking if:
 		//  - it's a method (due to @Override)
 		//  - it's a constructor and there was more than one
 		if (paramsCount1 > paramsCount2 && (e1.isMethod() || paramsCount1 > 1)) {
-			bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_REMOVED, e1, e2);
+			e1.getFormalTypeParameters().subList(paramsCount2, paramsCount1)
+				.forEach(ftp ->
+					bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_REMOVED, e1, e2,
+						new BreakingChangeDetails.MethodFormalTypeParametersRemoved(ftp)));
+			return;
 		}
 
 		// Adding a type parameter is only breaking if there was already some
 		if (paramsCount1 > 0 && paramsCount1 < paramsCount2) {
-			bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_ADDED, e1, e2);
+			e2.getFormalTypeParameters().subList(paramsCount1, paramsCount2)
+				.forEach(ftp ->
+					bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_ADDED, e1, e2,
+						new BreakingChangeDetails.MethodFormalTypeParametersAdded(ftp)));
+			return;
 		}
 
 		for (int i = 0; i < paramsCount1; i++) {
-			List<ITypeReference> bounds1 = e1.getFormalTypeParameters().get(i).bounds();
+			FormalTypeParameter ftp1 = e1.getFormalTypeParameters().get(i);
+			List<ITypeReference> bounds1 = ftp1.bounds();
 
 			if (i < paramsCount2) {
-				List<ITypeReference> bounds2 = e2.getFormalTypeParameters().get(i).bounds();
+				FormalTypeParameter ftp2 = e2.getFormalTypeParameters().get(i);
+				List<ITypeReference> bounds2 = ftp2.bounds();
 
 				if (e1.isMethod()) { // Invariant
 					if (!new HashSet<>(bounds1).equals(new HashSet<>(bounds2))) {
@@ -387,7 +421,8 @@ public class APIDiff {
 						// We can safely ignore this bound
 						.filter(b2 -> !b2.equals(TypeReference.OBJECT))
 						.anyMatch(b2 -> bounds1.stream().noneMatch(b1 -> v1.isSubtypeOf(b1, b2)))) {
-						bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_CHANGED, e1, e2);
+						bc(BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_CHANGED, e1, e2,
+							new BreakingChangeDetails.MethodFormalTypeParametersChanged(ftp1, ftp2));
 					}
 				}
 			}
@@ -398,7 +433,8 @@ public class APIDiff {
 		bc(kind, impactedSymbol, newSymbol, new BreakingChangeDetails.None());
 	}
 
-	private void bc(BreakingChangeKind kind, Symbol impactedSymbol, Symbol newSymbol, BreakingChangeDetails details) {
+	private void bc(BreakingChangeKind kind, Symbol impactedSymbol, Symbol newSymbol,
+	                BreakingChangeDetails details) {
 		BreakingChange bc = new BreakingChange(kind, impactedSymbol, newSymbol, details);
 		breakingChanges.add(bc);
 	}

--- a/core/src/main/java/io/github/alien/roseau/diff/RoseauReport.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/RoseauReport.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.changes.BreakingChange;
 
+import java.util.Comparator;
 import java.util.List;
 
 public record RoseauReport(
@@ -15,6 +16,9 @@ public record RoseauReport(
 		Preconditions.checkNotNull(v1);
 		Preconditions.checkNotNull(v2);
 		Preconditions.checkNotNull(breakingChanges);
-		breakingChanges = java.util.List.copyOf(breakingChanges);
+		breakingChanges = java.util.List.copyOf(
+			breakingChanges.stream()
+				.sorted(Comparator.comparing(bc -> bc.impactedSymbol().getQualifiedName()))
+				.toList());
 	}
 }

--- a/core/src/main/java/io/github/alien/roseau/diff/RoseauReport.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/RoseauReport.java
@@ -1,20 +1,20 @@
 package io.github.alien.roseau.diff;
 
 import com.google.common.base.Preconditions;
-import io.github.alien.roseau.Library;
+import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.changes.BreakingChange;
 
 import java.util.List;
 
 public record RoseauReport(
-	Library v1,
-	Library v2,
+	API v1,
+	API v2,
 	List<BreakingChange> breakingChanges
 ) {
 	public RoseauReport {
 		Preconditions.checkNotNull(v1);
 		Preconditions.checkNotNull(v2);
 		Preconditions.checkNotNull(breakingChanges);
-		breakingChanges = List.copyOf(breakingChanges);
+		breakingChanges = java.util.List.copyOf(breakingChanges);
 	}
 }

--- a/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChange.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChange.java
@@ -11,6 +11,7 @@ import io.github.alien.roseau.api.model.Symbol;
  * @param kind           The kind of breaking change
  * @param impactedSymbol The API symbol impacted by the breaking change
  * @param newSymbol      If applicable, the corresponding symbol in the new version
+ * @param details        Additional details about the breaking change
  * @see BreakingChangeKind
  */
 public record BreakingChange(

--- a/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChange.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChange.java
@@ -1,10 +1,9 @@
 package io.github.alien.roseau.diff.changes;
 
-import io.github.alien.roseau.api.model.LibraryTypes;
+import com.google.common.base.Preconditions;
 import io.github.alien.roseau.api.model.ExecutableDecl;
+import io.github.alien.roseau.api.model.LibraryTypes;
 import io.github.alien.roseau.api.model.Symbol;
-
-import java.util.Objects;
 
 /**
  * A breaking change identified when comparing two {@link LibraryTypes} instances.
@@ -17,11 +16,15 @@ import java.util.Objects;
 public record BreakingChange(
 	BreakingChangeKind kind,
 	Symbol impactedSymbol,
-	Symbol newSymbol
+	Symbol newSymbol,
+	BreakingChangeDetails details
 ) {
 	public BreakingChange {
-		Objects.requireNonNull(kind);
-		Objects.requireNonNull(impactedSymbol);
+		Preconditions.checkNotNull(kind);
+		Preconditions.checkNotNull(impactedSymbol);
+		if (details == null) {
+			details = new BreakingChangeDetails.None();
+		}
 	}
 
 	private static String printSymbol(Symbol s) {

--- a/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChangeDetails.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChangeDetails.java
@@ -1,14 +1,52 @@
 package io.github.alien.roseau.diff.changes;
 
+import io.github.alien.roseau.api.model.FormalTypeParameter;
 import io.github.alien.roseau.api.model.MethodDecl;
+import io.github.alien.roseau.api.model.ParameterDecl;
+import io.github.alien.roseau.api.model.TypeDecl;
 import io.github.alien.roseau.api.model.reference.ITypeReference;
+import io.github.alien.roseau.api.model.reference.TypeReference;
+
+import java.lang.annotation.ElementType;
+import java.util.List;
+import java.util.Set;
 
 public sealed interface BreakingChangeDetails {
 	record None() implements BreakingChangeDetails {}
-
-	record MethodReturnTypeChanged(
-		ITypeReference previousType, ITypeReference newType)
+	record MethodReturnTypeChanged(ITypeReference previousType, ITypeReference newType)
 		implements BreakingChangeDetails {}
-	record MethodAddedToInterface(MethodDecl newMethod) implements BreakingChangeDetails {}
-	record MethodAbstractAddedToClass(MethodDecl newMethod) implements BreakingChangeDetails {}
+	record FieldTypeChanged(ITypeReference previousType, ITypeReference newType)
+		implements BreakingChangeDetails {}
+	record MethodAddedToInterface(MethodDecl newMethod)
+		implements BreakingChangeDetails {}
+	record MethodAbstractAddedToClass(MethodDecl newMethod)
+		implements BreakingChangeDetails {}
+	record ClassTypeChanged(Class<?> oldType, Class<?> newType)
+		implements BreakingChangeDetails {}
+	record SuperTypeRemoved(TypeReference<TypeDecl> superType)
+		implements BreakingChangeDetails {}
+	record AnnotationTargetRemoved(ElementType target)
+		implements BreakingChangeDetails {}
+	record MethodNoLongerThrowsCheckedException(ITypeReference exception)
+		implements BreakingChangeDetails {}
+	record MethodNowThrowsCheckedException(ITypeReference exception)
+		implements BreakingChangeDetails {}
+	record MethodParameterGenericsChanged(ParameterDecl parameter,
+	                                      ITypeReference oldType,
+	                                      ITypeReference newType)
+		implements BreakingChangeDetails {}
+	record TypeFormalTypeParametersRemoved(FormalTypeParameter ftp)
+		implements BreakingChangeDetails {}
+	record TypeFormalTypeParametersAdded(FormalTypeParameter ftp)
+		implements BreakingChangeDetails {}
+	record TypeFormalTypeParametersChanged(FormalTypeParameter oldFtp,
+	                                       FormalTypeParameter newFtp)
+		implements BreakingChangeDetails {}
+	record MethodFormalTypeParametersRemoved(FormalTypeParameter ftp)
+		implements BreakingChangeDetails {}
+	record MethodFormalTypeParametersAdded(FormalTypeParameter ftp)
+		implements BreakingChangeDetails {}
+	record MethodFormalTypeParametersChanged(FormalTypeParameter oldFtp,
+	                                       FormalTypeParameter newFtp)
+		implements BreakingChangeDetails {}
 }

--- a/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChangeDetails.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/changes/BreakingChangeDetails.java
@@ -1,0 +1,14 @@
+package io.github.alien.roseau.diff.changes;
+
+import io.github.alien.roseau.api.model.MethodDecl;
+import io.github.alien.roseau.api.model.reference.ITypeReference;
+
+public sealed interface BreakingChangeDetails {
+	record None() implements BreakingChangeDetails {}
+
+	record MethodReturnTypeChanged(
+		ITypeReference previousType, ITypeReference newType)
+		implements BreakingChangeDetails {}
+	record MethodAddedToInterface(MethodDecl newMethod) implements BreakingChangeDetails {}
+	record MethodAbstractAddedToClass(MethodDecl newMethod) implements BreakingChangeDetails {}
+}

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatter.java
@@ -13,5 +13,5 @@ public interface BreakingChangesFormatter {
 	 * @param report the report to format
 	 * @return the formatted list
 	 */
-	String format(API api, RoseauReport report);
+	String format(RoseauReport report);
 }

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatterFactory.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatterFactory.java
@@ -1,10 +1,8 @@
 package io.github.alien.roseau.diff.formatter;
 
-import javax.swing.text.html.HTML;
-
 /**
- * A factory of {@link BreakingChangesFormatter} given an expected output format. Currently, supports CSV, HTML, and
- * JSON.
+ * A factory of {@link BreakingChangesFormatter} given an expected output format. Currently, supports CLI, CSV, HTML,
+ * and JSON.
  */
 public enum BreakingChangesFormatterFactory {
 	CLI,
@@ -20,7 +18,7 @@ public enum BreakingChangesFormatterFactory {
 	 */
 	public static BreakingChangesFormatter newBreakingChangesFormatter(BreakingChangesFormatterFactory format) {
 		return switch (format) {
-			case CLI -> new CliFormatter();
+			case CLI -> new CliFormatter(false);
 			case JSON -> new JsonFormatter();
 			case CSV -> new CsvFormatter();
 			case HTML -> new HtmlFormatter();

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatterFactory.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatterFactory.java
@@ -1,10 +1,13 @@
 package io.github.alien.roseau.diff.formatter;
 
+import javax.swing.text.html.HTML;
+
 /**
  * A factory of {@link BreakingChangesFormatter} given an expected output format. Currently, supports CSV, HTML, and
  * JSON.
  */
 public enum BreakingChangesFormatterFactory {
+	CLI,
 	CSV,
 	HTML,
 	JSON;
@@ -17,6 +20,7 @@ public enum BreakingChangesFormatterFactory {
 	 */
 	public static BreakingChangesFormatter newBreakingChangesFormatter(BreakingChangesFormatterFactory format) {
 		return switch (format) {
+			case CLI -> new CliFormatter();
 			case JSON -> new JsonFormatter();
 			case CSV -> new CsvFormatter();
 			case HTML -> new HtmlFormatter();

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/CliFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/CliFormatter.java
@@ -9,10 +9,16 @@ import java.util.stream.Collectors;
  * A formatter of {@link RoseauReport} that produces a CSV output.
  */
 public class CliFormatter implements BreakingChangesFormatter {
+	private final boolean plain;
+
 	private static final String RED_TEXT = "\u001B[31m";
 	private static final String BOLD = "\u001B[1m";
 	private static final String UNDERLINE = "\u001B[4m";
 	private static final String RESET = "\u001B[0m";
+
+	public CliFormatter(boolean plain) {
+		this.plain = plain;
+	}
 
 	@Override
 	public String format(RoseauReport report) {
@@ -20,14 +26,50 @@ public class CliFormatter implements BreakingChangesFormatter {
 			.map(bc -> {
 				String details = switch (bc.details()) {
 					case BreakingChangeDetails.None d -> "";
+
 					case BreakingChangeDetails.MethodReturnTypeChanged(var oldType, var newType) ->
 						"old: %s, new: %s".formatted(oldType, newType);
-					case BreakingChangeDetails.MethodAddedToInterface(var newMethod) -> "method: " + newMethod.getSignature();
-					case BreakingChangeDetails.MethodAbstractAddedToClass(var newMethod) -> "method: " + newMethod.getSignature();
-					default -> "";
+					case BreakingChangeDetails.FieldTypeChanged(var oldType, var newType) ->
+						"old: %s, new: %s".formatted(oldType, newType);
+
+					case BreakingChangeDetails.MethodAddedToInterface(var newMethod) ->
+						"method: " + newMethod.getSignature();
+					case BreakingChangeDetails.MethodAbstractAddedToClass(var newMethod) ->
+						"method: " + newMethod.getSignature();
+
+					case BreakingChangeDetails.SuperTypeRemoved(var type) ->
+						"type: " + type;
+
+					case BreakingChangeDetails.AnnotationTargetRemoved(var target) ->
+						"target: " + target;
+
+					case BreakingChangeDetails.ClassTypeChanged(var oldType, var newType) ->
+						"old: %s, new: %s".formatted(oldType.getSimpleName(), newType.getSimpleName());
+
+					case BreakingChangeDetails.MethodNoLongerThrowsCheckedException(var exc) ->
+						"exception: " + exc;
+					case BreakingChangeDetails.MethodNowThrowsCheckedException(var exc) ->
+						"exception: " + exc;
+
+					case BreakingChangeDetails.MethodFormalTypeParametersAdded(var ftp) ->
+						"type parameter: " + ftp;
+					case BreakingChangeDetails.MethodFormalTypeParametersRemoved(var ftp) ->
+						"type parameter: " + ftp;
+					case BreakingChangeDetails.TypeFormalTypeParametersAdded(var ftp) ->
+						"type parameter: " + ftp;
+					case BreakingChangeDetails.TypeFormalTypeParametersRemoved(var ftp) ->
+						"type parameter: " + ftp;
+
+					case BreakingChangeDetails.MethodFormalTypeParametersChanged(var oldFtp, var newFtp) ->
+						"type parameter: " + oldFtp + " -> " + newFtp;
+					case BreakingChangeDetails.TypeFormalTypeParametersChanged(var oldFtp, var newFtp) ->
+						"type parameter: " + oldFtp + " -> " + newFtp;
+
+					case BreakingChangeDetails.MethodParameterGenericsChanged(var param, var oldFtp, var newFtp) ->
+						"param: " + param.name() + ", type: " + oldFtp + " -> " + newFtp;
 				};
 
-				if (false) { // plaoin
+				if (plain) {
 					return String.format("%s %s%s%n\t%s:%s", bc.kind(), bc.impactedSymbol().getQualifiedName(),
 						details.isEmpty() ? "" : " [%s]".formatted(details),
 						bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/CliFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/CliFormatter.java
@@ -1,0 +1,42 @@
+package io.github.alien.roseau.diff.formatter;
+
+import io.github.alien.roseau.diff.RoseauReport;
+import io.github.alien.roseau.diff.changes.BreakingChangeDetails;
+
+import java.util.stream.Collectors;
+
+/**
+ * A formatter of {@link RoseauReport} that produces a CSV output.
+ */
+public class CliFormatter implements BreakingChangesFormatter {
+	private static final String RED_TEXT = "\u001B[31m";
+	private static final String BOLD = "\u001B[1m";
+	private static final String UNDERLINE = "\u001B[4m";
+	private static final String RESET = "\u001B[0m";
+
+	@Override
+	public String format(RoseauReport report) {
+		return report.breakingChanges().stream()
+			.map(bc -> {
+				String details = switch (bc.details()) {
+					case BreakingChangeDetails.None d -> "";
+					case BreakingChangeDetails.MethodReturnTypeChanged(var oldType, var newType) ->
+						"old: %s, new: %s".formatted(oldType, newType);
+					case BreakingChangeDetails.MethodAddedToInterface(var newMethod) -> "method: " + newMethod.getSignature();
+					case BreakingChangeDetails.MethodAbstractAddedToClass(var newMethod) -> "method: " + newMethod.getSignature();
+				};
+
+				if (false) { // plaoin
+					return String.format("%s %s%s%n\t%s:%s", bc.kind(), bc.impactedSymbol().getQualifiedName(),
+						details.isEmpty() ? "" : " [%s]".formatted(details),
+						bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
+				} else {
+					return String.format("%s %s%s%n\t%s:%s",
+						RED_TEXT + BOLD + bc.kind() + RESET,
+						UNDERLINE + bc.impactedSymbol().getQualifiedName() + RESET,
+						details.isEmpty() ? "" : " [%s]".formatted(details),
+						bc.impactedSymbol().getLocation().file(), bc.impactedSymbol().getLocation().line());
+				}
+			}).collect(Collectors.joining(System.lineSeparator()));
+	}
+}

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/CliFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/CliFormatter.java
@@ -24,6 +24,7 @@ public class CliFormatter implements BreakingChangesFormatter {
 						"old: %s, new: %s".formatted(oldType, newType);
 					case BreakingChangeDetails.MethodAddedToInterface(var newMethod) -> "method: " + newMethod.getSignature();
 					case BreakingChangeDetails.MethodAbstractAddedToClass(var newMethod) -> "method: " + newMethod.getSignature();
+					default -> "";
 				};
 
 				if (false) { // plaoin

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/CsvFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/CsvFormatter.java
@@ -1,6 +1,5 @@
 package io.github.alien.roseau.diff.formatter;
 
-import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.RoseauReport;
 
 import java.util.stream.Collectors;
@@ -10,7 +9,7 @@ import java.util.stream.Collectors;
  */
 public class CsvFormatter implements BreakingChangesFormatter {
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		return "element,oldPosition,newPosition,kind,nature" + System.lineSeparator() +
 			report.breakingChanges().stream().map(bc -> "%s,%s,%s,%s,%s".formatted(
 				bc.impactedSymbol().getQualifiedName(),

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/HtmlFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/HtmlFormatter.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  */
 public class HtmlFormatter implements BreakingChangesFormatter {
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		StringBuilder sb = new StringBuilder();
 		HtmlFlow.doc(sb)
 			.html()
@@ -42,7 +42,7 @@ public class HtmlFormatter implements BreakingChangesFormatter {
 			.div().addAttr("class", "container mt-5")
 			.h1().text("Breaking Changes Report").__()
 			.table().addAttr("class", "table")
-			.of(table -> getImpactedApiTree(api, report.breakingChanges()).forEach(node ->
+			.of(table -> getImpactedApiTree(report).forEach(node ->
 				table.tr().of(tr -> appendNode(tr, node)).__()
 					.of(theTable -> node.children.forEach(member -> theTable.tr().of(tr -> appendNode(tr, member)).__()))
 			))
@@ -68,9 +68,9 @@ public class HtmlFormatter implements BreakingChangesFormatter {
 			.__();
 	}
 
-	private static List<TypeNode> getImpactedApiTree(API api, List<BreakingChange> changes) {
+	private static List<TypeNode> getImpactedApiTree(RoseauReport report) {
 		Map<Symbol, Node> nodes = new HashMap<>();
-		for (BreakingChange change : changes) {
+		for (BreakingChange change : report.breakingChanges()) {
 			Symbol sym = change.impactedSymbol();
 			switch (sym) {
 				case TypeDecl td:
@@ -78,7 +78,7 @@ public class HtmlFormatter implements BreakingChangesFormatter {
 					nodes.get(sym).addBreakingChange(change);
 					break;
 				case TypeMemberDecl tmd:
-					Optional<TypeDecl> opt = api.resolver().resolve(tmd.getContainingType());
+					Optional<TypeDecl> opt = report.v1().resolver().resolve(tmd.getContainingType());
 					opt.ifPresent(container -> {
 						nodes.computeIfAbsent(container, k -> fromTypeDecl(container));
 						nodes.computeIfAbsent(sym, k -> fromTypeMemberDecl(tmd));

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/JsonFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/JsonFormatter.java
@@ -1,6 +1,5 @@
 package io.github.alien.roseau.diff.formatter;
 
-import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.api.model.SourceLocation;
 import io.github.alien.roseau.diff.RoseauReport;
 import io.github.alien.roseau.diff.changes.BreakingChange;
@@ -15,7 +14,7 @@ public class JsonFormatter implements BreakingChangesFormatter {
 	 * Formats the list of breaking changes in JSON format
 	 */
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		JSONArray jsonArray = new JSONArray();
 
 		for (BreakingChange bc : report.breakingChanges()) {

--- a/core/src/test/java/io/github/alien/roseau/diff/AnnotationTargetRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/AnnotationTargetRemovedTest.java
@@ -4,6 +4,7 @@ import io.github.alien.roseau.diff.changes.BreakingChangeKind;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertBCs;
 import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
@@ -106,7 +107,7 @@ class AnnotationTargetRemovedTest {
 				String value();
 			}""";
 
-		assertBC("A", BreakingChangeKind.ANNOTATION_TARGET_REMOVED, 1, buildDiff(v1, v2));
+		assertBCs("A", BreakingChangeKind.ANNOTATION_TARGET_REMOVED, 1, buildDiff(v1, v2));
 	}
 
 	@Test

--- a/core/src/test/java/io/github/alien/roseau/utils/TestUtils.java
+++ b/core/src/test/java/io/github/alien/roseau/utils/TestUtils.java
@@ -58,6 +58,24 @@ public class TestUtils {
 	private TestUtils() {
 	}
 
+	public static void assertBCs(String symbol, BreakingChangeKind kind, int line, List<BreakingChange> bcs) {
+		List<BreakingChange> matches = bcs.stream()
+			.filter(bc ->
+				kind == bc.kind()
+					&& line == bc.impactedSymbol().getLocation().line()
+					&& symbol.equals(bc.impactedSymbol().getQualifiedName())
+			).toList();
+
+		if (matches.isEmpty()) {
+			String desc = "[%s, %s, %d]".formatted(symbol, kind, line);
+			String found = bcs.stream()
+				.map(bc -> "[%s, %s, %d, %s]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(),
+					bc.impactedSymbol().getLocation().line(), bc.details()))
+				.collect(Collectors.joining(", "));
+			throw new AssertionFailedError("No breaking change", desc, found);
+		}
+	}
+
 	public static void assertBC(String symbol, BreakingChangeKind kind, int line, List<BreakingChange> bcs) {
 		List<BreakingChange> matches = bcs.stream()
 			.filter(bc ->
@@ -69,7 +87,8 @@ public class TestUtils {
 		if (matches.size() != 1) {
 			String desc = "[%s, %s, %d]".formatted(symbol, kind, line);
 			String found = bcs.stream()
-				.map(bc -> "[%s, %s, %d]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(), bc.impactedSymbol().getLocation().line()))
+				.map(bc -> "[%s, %s, %d, %s]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(),
+					bc.impactedSymbol().getLocation().line(), bc.details()))
 				.collect(Collectors.joining(", "));
 			throw new AssertionFailedError("No breaking change", desc, found);
 		}
@@ -78,7 +97,8 @@ public class TestUtils {
 	public static void assertNoBC(List<BreakingChange> bcs) {
 		if (!bcs.isEmpty()) {
 			String found = bcs.stream()
-				.map(bc -> "[%s, %s, %d]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(), bc.impactedSymbol().getLocation().line()))
+				.map(bc -> "[%s, %s, %d, %s]".formatted(bc.impactedSymbol().getQualifiedName(),
+					bc.kind(), bc.impactedSymbol().getLocation().line(), bc.details()))
 				.collect(Collectors.joining(", "));
 			throw new AssertionFailedError("Unexpected breaking change", "No breaking change", found);
 		}
@@ -87,7 +107,8 @@ public class TestUtils {
 	public static void assertNoBC(BreakingChangeKind kind, List<BreakingChange> bcs) {
 		String found = bcs.stream()
 			.filter(bc -> bc.kind() == kind)
-			.map(bc -> "[%s, %s, %d]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(), bc.impactedSymbol().getLocation().line()))
+			.map(bc -> "[%s, %s, %d, %s]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(),
+				bc.impactedSymbol().getLocation().line(), bc.details()))
 			.collect(Collectors.joining(", "));
 
 		if (!found.isEmpty())
@@ -97,7 +118,8 @@ public class TestUtils {
 	public static void assertNoBC(int line, List<BreakingChange> bcs) {
 		String found = bcs.stream()
 			.filter(bc -> bc.impactedSymbol().getLocation().line() == line)
-			.map(bc -> "[%s, %s, %d]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(), bc.impactedSymbol().getLocation().line()))
+			.map(bc -> "[%s, %s, %d, %s]".formatted(bc.impactedSymbol().getQualifiedName(), bc.kind(),
+				bc.impactedSymbol().getLocation().line(), bc.details()))
 			.collect(Collectors.joining(", "));
 
 		if (!found.isEmpty())


### PR DESCRIPTION
Trying to improve reporting in several ways:

- [X] Decorate certain BCs with BC-specific details (e.g., the type that's been removed for `SUPERTYPE_REMOVED`, the new abstract method for `METHOD_ADDED_TO_INTERFACE`, etc.)
- [X] Centralize console pretty-printing in `CliFormatter`
- [X] Make the ordering of BCs in `RoseauReport` deterministic so that analyzing the two same versions always yields the same result
- [ ] Revisit the kinds of BCs we consider: names can be vastly improved, different kinds can be merged/split, etc.
- [ ] Revisit the existing formatters (CSV, JSON, HTML) to include the new information and respect ordering
- [ ] Design a new API report that pretty prints APIs as HTML to explore API surface
- [ ] Re-design the HTML BCs report

So far, CLI reports looks like with additional BC details:

```
METHOD_ABSTRACT_ADDED_TO_CLASS pkg.AbstractAdded [method: newly()]
	example-api/v1/pkg/AbstractAdded.java:4
FIELD_TYPE_CHANGED pkg.FieldsClass.d [old: java.lang.String, new: java.lang.CharSequence]
	example-api/v1/pkg/FieldsClass.java:14
TYPE_FORMAL_TYPE_PARAMETERS_CHANGED pkg.GenericChanged [type parameter: T extends java.lang.Number -> T extends java.lang.CharSequence]
	example-api/v1/pkg/GenericChanged.java:4
TYPE_FORMAL_TYPE_PARAMETERS_REMOVED pkg.GenericRemoved [type parameter: T extends java.lang.Object]
	example-api/v1/pkg/GenericRemoved.java:4
SUPERTYPE_REMOVED pkg.Hierarchy [type: java.lang.Runnable]
	example-api/v1/pkg/Hierarchy.java:3
METHOD_FORMAL_TYPE_PARAMETERS_CHANGED pkg.MethodTypeParameters.changedTP [type parameter: T extends java.lang.Number -> T extends java.lang.CharSequence]
	example-api/v1/pkg/MethodTypeParameters.java:11
METHOD_FORMAL_TYPE_PARAMETERS_REMOVED pkg.MethodTypeParameters.removedTP [type parameter: T extends java.lang.Object]
	example-api/v1/pkg/MethodTypeParameters.java:5
METHOD_RETURN_TYPE_CHANGED pkg.MethodsClass.m1 [old: int, new: long]
	example-api/v1/pkg/MethodsClass.java:7
METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION pkg.MethodsClass.m5 [exception: java.io.IOException]
	example-api/v1/pkg/MethodsClass.java:19
METHOD_NOW_THROWS_CHECKED_EXCEPTION pkg.MethodsClass.m6 [exception: java.io.IOException]
	example-api/v1/pkg/MethodsClass.java:22
METHOD_PARAMETER_GENERICS_CHANGED pkg.MethodsClass.params [param: list, type: java.util.List<java.lang.String> -> java.util.List<java.lang.Number>]
	example-api/v1/pkg/MethodsClass.java:25
SUPERTYPE_REMOVED pkg.MyProblem [type: java.lang.RuntimeException]
	example-api/v1/pkg/MyProblem.java:4
METHOD_ADDED_TO_INTERFACE pkg.SimpleI [method: b()]
	example-api/v1/pkg/SimpleI.java:4
```
