### PR TITLE
Generate a standalone BCs dataset from our test suite

### DIFF
--- a/core/src/test/java/io/github/alien/roseau/diff/AnnotationMethodAddedWithoutDefaultTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/AnnotationMethodAddedWithoutDefaultTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,31 +9,33 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class AnnotationMethodAddedWithoutDefaultTest {
+	@Client("@A(i=0) int a;")
 	@Test
 	void new_annotation_method_without_default() {
 		var v1 = """
 			public @interface A {
-				String s();
+				int i();
 			}""";
 		var v2 = """
 			public @interface A {
-				String s();
 				int i();
+				String s();
 			}""";
 
 		assertBC("A", BreakingChangeKind.ANNOTATION_METHOD_ADDED_WITHOUT_DEFAULT, 1, buildDiff(v1, v2));
 	}
 
+	@Client("@A(i=0) int a;")
 	@Test
 	void new_annotation_method_with_default() {
 		var v1 = """
 			public @interface A {
-				String s();
+				int i();
 			}""";
 		var v2 = """
 			public @interface A {
-				String s();
-				int i() default 0;
+				int i();
+				String s() default "";
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));

--- a/core/src/test/java/io/github/alien/roseau/diff/AnnotationMethodNoLongerDefaultTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/AnnotationMethodNoLongerDefaultTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class AnnotationMethodNoLongerDefaultTest {
+	@Client("@A int i;")
 	@Test
 	void annotation_method_no_longer_default() {
 		var v1 = """
@@ -22,15 +24,16 @@ class AnnotationMethodNoLongerDefaultTest {
 		assertBC("A.value", BreakingChangeKind.ANNOTATION_METHOD_NO_LONGER_DEFAULT, 2, buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int a;")
 	@Test
 	void annotation_method_now_default() {
 		var v1 = """
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			public @interface A {
-				String value() default "";
+				int value() default 0;
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));

--- a/core/src/test/java/io/github/alien/roseau/diff/AnnotationNoLongerRepeatableTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/AnnotationNoLongerRepeatableTest.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class AnnotationNoLongerRepeatableTest {
+	@Client("@A @A int a;")
 	@Test
 	void annotation_no_longer_repeatable() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/AnnotationTargetRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/AnnotationTargetRemovedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,74 +9,78 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class AnnotationTargetRemovedTest {
+	@Client("@A(0) int a;")
 	@Test
 	void annotation_target_changed() {
 		var v1 = """
-			@java.lang.annotation.Target(java.lang.annotation.ElementType.FIELD)
+			@java.lang.annotation.Target(java.lang.annotation.ElementType.LOCAL_VARIABLE)
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			@java.lang.annotation.Target(java.lang.annotation.ElementType.METHOD)
 			public @interface A {
-				String value();
+				int value();
 			}""";
 
 		assertBC("A", BreakingChangeKind.ANNOTATION_TARGET_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int a;")
 	@Test
 	void annotation_target_removed() {
 		var v1 = """
 			@java.lang.annotation.Target({
 				java.lang.annotation.ElementType.FIELD,
 				java.lang.annotation.ElementType.METHOD,
-				java.lang.annotation.ElementType.TYPE
+				java.lang.annotation.ElementType.LOCAL_VARIABLE
 			})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			@java.lang.annotation.Target({
 				java.lang.annotation.ElementType.FIELD,
-				java.lang.annotation.ElementType.TYPE
+				java.lang.annotation.ElementType.METHOD
 			})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 
 		assertBC("A", BreakingChangeKind.ANNOTATION_TARGET_REMOVED, 6, buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int a;")
 	@Test
 	void annotation_target_added() {
 		var v1 = """
 			@java.lang.annotation.Target({
 				java.lang.annotation.ElementType.FIELD,
-				java.lang.annotation.ElementType.TYPE
+				java.lang.annotation.ElementType.LOCAL_VARIABLE
 			})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			@java.lang.annotation.Target({
 				java.lang.annotation.ElementType.FIELD,
-				java.lang.annotation.ElementType.METHOD,
+				java.lang.annotation.ElementType.LOCAL_VARIABLE,
 				java.lang.annotation.ElementType.TYPE
 			})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int a;")
 	@Test
 	void default_annotation_target_compatible() {
 		// Default to all except TYPE_USE
 		var v1 = """
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			@java.lang.annotation.Target({
@@ -87,28 +92,30 @@ class AnnotationTargetRemovedTest {
 				java.lang.annotation.ElementType.RECORD_COMPONENT
 			})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int a;")
 	@Test
 	void default_annotation_target_incompatible() {
 		// Default to all except TYPE_USE
 		var v1 = """
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			@java.lang.annotation.Target({java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 
 		assertBC("A", BreakingChangeKind.ANNOTATION_TARGET_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("// No uses")
 	@Test
 	void empty_annotation_target_compatible() {
 		// @Target({}) cannot be used anywhere
@@ -126,18 +133,19 @@ class AnnotationTargetRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int a;")
 	@Test
 	void empty_annotation_target_incompatible() {
 		// @Target({}) cannot be used anywhere
 		var v1 = """
-			@java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE)
+			@java.lang.annotation.Target(java.lang.annotation.ElementType.LOCAL_VARIABLE)
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = """
 			@java.lang.annotation.Target({})
 			public @interface A {
-				String value();
+				int value();
 			}""";
 
 		assertBC("A", BreakingChangeKind.ANNOTATION_TARGET_REMOVED, 2, buildDiff(v1, v2));

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowAbstractTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowAbstractTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ClassNowAbstractTest {
+	@Client("A a = new A();")
 	@Test
 	void class_now_abstract() {
 		var v1 = "public class A {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowAbstractTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowAbstractTest.java
@@ -27,7 +27,7 @@ class ClassNowAbstractTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
-	@Client("new A(){};")
+	@Client("// No uses")
 	@Test
 	void implicitly_abstract_class_now_explicitly_abstract() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowAbstractTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowAbstractTest.java
@@ -9,7 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ClassNowAbstractTest {
-	@Client("A a = new A();")
+	@Client("new A();")
 	@Test
 	void class_now_abstract() {
 		var v1 = "public class A {}";
@@ -18,6 +18,7 @@ class ClassNowAbstractTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_ABSTRACT, 1, buildDiff(v1, v2));
 	}
 
+	@Client("new I(){};")
 	@Test
 	void interface_now_abstract() {
 		var v1 = "public interface I {}";
@@ -26,6 +27,7 @@ class ClassNowAbstractTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("new A(){};")
 	@Test
 	void implicitly_abstract_class_now_explicitly_abstract() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowCheckedExceptionTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowCheckedExceptionTest.java
@@ -48,7 +48,13 @@ class ClassNowCheckedExceptionTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_CHECKED_EXCEPTION, 1, buildDiff(v1, v2));
 	}
 
-	@Client("throw new A();")
+	@Client("""
+		try {
+			throw new A();
+		} catch (A e) {}
+		try {
+			throw new A();
+		} catch (Exception e) {}""")
 	@Test
 	void checked_exception_becomes_specific() {
 		var v1 = "public class A extends Exception {}";
@@ -60,7 +66,7 @@ class ClassNowCheckedExceptionTest {
 	@Client("""
 		try {
 			throw new A();
-		} catch (IOException e) {}""")
+		} catch (java.io.IOException e) {}""")
 	@Test
 	void specific_exception_becomes_generic() {
 		var v1 = "public class A extends java.io.IOException {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowCheckedExceptionTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowCheckedExceptionTest.java
@@ -1,13 +1,18 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
+import org.xmlet.htmlapifaster.A;
+
+import java.io.IOException;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ClassNowCheckedExceptionTest {
+	@Client("new A();")
 	@Test
 	void class_becomes_generic_checked_exception() {
 		var v1 = "public class A {}";
@@ -16,6 +21,7 @@ class ClassNowCheckedExceptionTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("new A();")
 	@Test
 	void class_becomes_specific_checked_exception() {
 		var v1 = "public class A {}";
@@ -24,6 +30,7 @@ class ClassNowCheckedExceptionTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("throw new A();")
 	@Test
 	void unchecked_exception_becomes_checked_exception() {
 		var v1 = "public class A extends RuntimeException {}";
@@ -32,6 +39,7 @@ class ClassNowCheckedExceptionTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_CHECKED_EXCEPTION, 1, buildDiff(v1, v2));
 	}
 
+	@Client("throw new A();")
 	@Test
 	void specific_unchecked_exception_becomes_specific_checked_exception() {
 		var v1 = "public class A extends IllegalArgumentException {}";
@@ -40,6 +48,7 @@ class ClassNowCheckedExceptionTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_CHECKED_EXCEPTION, 1, buildDiff(v1, v2));
 	}
 
+	@Client("throw new A();")
 	@Test
 	void checked_exception_becomes_specific() {
 		var v1 = "public class A extends Exception {}";
@@ -48,6 +57,10 @@ class ClassNowCheckedExceptionTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("""
+		try {
+			throw new A();
+		} catch (IOException e) {}""")
 	@Test
 	void specific_exception_becomes_generic() {
 		var v1 = "public class A extends java.io.IOException {}";
@@ -56,6 +69,7 @@ class ClassNowCheckedExceptionTest {
 		assertNoBC(BreakingChangeKind.CLASS_NOW_CHECKED_EXCEPTION, buildDiff(v1, v2));
 	}
 
+	@Client("new A();")
 	@Test
 	void class_becomes_runtime_exception() {
 		var v1 = "public class A {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowFinalTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowFinalTest.java
@@ -75,17 +75,18 @@ class ClassNowFinalTest {
 		assertBC("A$B", BreakingChangeKind.CLASS_NOW_FINAL, 2, buildDiff(v1, v2));
 	}
 
+	@Client("E a = E.A;")
 	@Test
 	void enummm() {
 		// JLS §8.9:
 		// An enum class is either implicitly final or implicitly sealed, as follows:
-		//    An enum class is implicitly final if its declaration contains no enum constants
-		//    that have a class body (§8.9.1).
+		// An enum class is implicitly final if its declaration contains no enum constants
+		// that have a class body (§8.9.1).
 
-		//    An enum class E is implicitly sealed if its declaration contains at least one enum
-		//    constant that has a class body. The permitted direct subclasses (§8.1.6) of E are
-		//    the anonymous classes implicitly declared by the enum constants that have a
-		//    class body.
+		// An enum class E is implicitly sealed if its declaration contains at least one enum
+		// constant that has a class body. The permitted direct subclasses (§8.1.6) of E are
+		// the anonymous classes implicitly declared by the enum constants that have a
+		// class body.
 		var v1 = """
 			public enum E {
 				A;

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassNowFinalTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassNowFinalTest.java
@@ -1,13 +1,16 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
+import org.xmlet.htmlapifaster.A;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ClassNowFinalTest {
+	@Client("new A(){};")
 	@Test
 	void class_now_final() {
 		var v1 = "public class A {}";
@@ -16,6 +19,7 @@ class ClassNowFinalTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_FINAL, 1, buildDiff(v1, v2));
 	}
 
+	@Client("new A(){};")
 	@Test
 	void class_now_sealed() {
 		var v1 = "public class A {}";
@@ -26,6 +30,7 @@ class ClassNowFinalTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_FINAL, 1, buildDiff(v1, v2));
 	}
 
+	@Client("new A(){};")
 	@Test
 	void class_now_record() {
 		var v1 = "public class A {}";
@@ -34,6 +39,7 @@ class ClassNowFinalTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_FINAL, 1, buildDiff(v1, v2));
 	}
 
+	@Client("new A();")
 	@Test
 	void record_now_final() {
 		var v1 = "public record A() {}";
@@ -42,6 +48,7 @@ class ClassNowFinalTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("new A(){};")
 	@Test
 	void class_now_effectively_final() {
 		var v1 = "public class A {}";
@@ -53,6 +60,7 @@ class ClassNowFinalTest {
 		assertBC("A", BreakingChangeKind.CLASS_NOW_FINAL, 1, buildDiff(v1, v2));
 	}
 
+	@Client("new A.B(){};")
 	@Test
 	void nested_class_now_final() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
@@ -5,6 +5,7 @@ import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ClassTypeChangedTest {
@@ -17,13 +18,22 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
-	@Client("A a = new A();")
+	@Client("A a = new A(){};")
 	@Test
 	void class_to_record() {
 		var v1 = "public class A {}";
 		var v2 = "public record A() {}";
 
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
+	}
+
+	@Client("A a = new A();")
+	@Test
+	void final_class_to_record() {
+		var v1 = "public final class A {}";
+		var v2 = "public record A() {}";
+
+		assertNoBC(buildDiff(v1, v2));
 	}
 
 	@Client("A a = new A();")
@@ -35,7 +45,9 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
-	@Client("class C implements A {};")
+	@Client("""
+		class C implements A {};
+		A a = new A(); // Trigger the linker""")
 	@Test
 	void interface_to_class() {
 		var v1 = "public interface A {}";
@@ -44,7 +56,9 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
-	@Client("class C implements A {};")
+	@Client("""
+		class C implements A {};
+		A a = new A(); // Trigger the linker""")
 	@Test
 	void interface_to_record() {
 		var v1 = "public interface A {}";
@@ -53,7 +67,9 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
-	@Client("class C implements A {};")
+	@Client("""
+		class C implements A {};
+		A a = new A(); // Trigger the linker""")
 	@Test
 	void interface_to_enum() {
 		var v1 = "public interface A {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
@@ -47,7 +47,7 @@ class ClassTypeChangedTest {
 
 	@Client("""
 		class C implements A {};
-		A a = new A(); // Trigger the linker""")
+		C c = new C(); // Trigger the linker""")
 	@Test
 	void interface_to_class() {
 		var v1 = "public interface A {}";
@@ -58,7 +58,7 @@ class ClassTypeChangedTest {
 
 	@Client("""
 		class C implements A {};
-		A a = new A(); // Trigger the linker""")
+		C c = new C(); // Trigger the linker""")
 	@Test
 	void interface_to_record() {
 		var v1 = "public interface A {}";
@@ -69,7 +69,7 @@ class ClassTypeChangedTest {
 
 	@Client("""
 		class C implements A {};
-		A a = new A(); // Trigger the linker""")
+		C c = new C(); // Trigger the linker""")
 	@Test
 	void interface_to_enum() {
 		var v1 = "public interface A {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ClassTypeChangedTest {
+	@Client("A a = new A();")
 	@Test
 	void class_to_interface() {
 		var v1 = "public class A {}";
@@ -15,6 +17,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void class_to_record() {
 		var v1 = "public class A {}";
@@ -23,6 +26,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void class_to_enum() {
 		var v1 = "public class A {}";
@@ -31,6 +35,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("class C implements A {};")
 	@Test
 	void interface_to_class() {
 		var v1 = "public interface A {}";
@@ -39,6 +44,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("class C implements A {};")
 	@Test
 	void interface_to_record() {
 		var v1 = "public interface A {}";
@@ -47,6 +53,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("class C implements A {};")
 	@Test
 	void interface_to_enum() {
 		var v1 = "public interface A {}";
@@ -55,6 +62,10 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		switch (new A()) {
+			case A() -> {}
+		};""")
 	@Test
 	void record_to_class() {
 		var v1 = "public record A() {}";
@@ -63,6 +74,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void record_to_interface() {
 		var v1 = "public record A() {}";
@@ -71,6 +83,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = A.INSTANCE;")
 	@Test
 	void enum_to_class() {
 		var v1 = "public enum A { INSTANCE; }";
@@ -79,6 +92,7 @@ class ClassTypeChangedTest {
 		assertBC("A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = A.INSTANCE;")
 	@Test
 	void enum_to_interface() {
 		var v1 = "public enum A { INSTANCE; }";

--- a/core/src/test/java/io/github/alien/roseau/diff/ConstructorRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ConstructorRemovedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class ConstructorRemovedTest {
+	@Client("A a = new A();")
 	@Test
 	void class_default_constructor_removed() {
 		var v1 = "public class A {}";
@@ -19,6 +21,7 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, -1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void class_default_constructor_now_explicit() {
 		var v1 = "public class A {}";
@@ -30,6 +33,7 @@ class ConstructorRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void class_explicit_constructor_now_default() {
 		var v1 = """
@@ -41,6 +45,7 @@ class ConstructorRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void class_constructor_now_private() {
 		var v1 = "public class A {}";
@@ -52,6 +57,7 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, -1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(0);")
 	@Test
 	void class_constructor_now_protected() {
 		var v1 = """
@@ -68,6 +74,7 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_NOW_PROTECTED, 2, diff);
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void class_constructor_now_protected_default() {
 		var v1 = "public class A {}";
@@ -81,14 +88,16 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_NOW_PROTECTED, -1, diff);
 	}
 
+	@Client("A a = new A(0);")
 	@Test
 	void record_implicit_constructor_changed() {
 		var v1 = "public record A(int i) {}";
-		var v2 = "public record A(float f) {}";
+		var v2 = "public record A(String s) {}";
 
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, -1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(0);")
 	@Test
 	void record_implicit_constructor_changed_add() {
 		var v1 = "public record A(int i) {}";
@@ -97,6 +106,7 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, -1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(0, 0f);")
 	@Test
 	void record_implicit_constructor_changed_remove() {
 		var v1 = "public record A(int i, float f) {}";
@@ -105,6 +115,7 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, -1, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A();")
 	@Test
 	void record_explicit_constructor_removed() {
 		var v1 = """
@@ -120,11 +131,12 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(true);")
 	@Test
 	void record_explicit_constructor_changed() {
 		var v1 = """
 			public record A(int i) {
-				public A(float f) {
+				public A(boolean f) {
 					this(0);
 				}
 			}""";
@@ -138,6 +150,7 @@ class ConstructorRemovedTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(0);")
 	@Test
 	void record_default_constructor_removed() {
 		var v1 = """
@@ -151,6 +164,7 @@ class ConstructorRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(0);")
 	@Test
 	void class_constructor_changed() {
 		var v1 = """
@@ -159,18 +173,19 @@ class ConstructorRemovedTest {
 			}""";
 		var v2 = """
 			public class A {
-				public A(float f) {}
+				public A(String s) {}
 			}""";
 
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(true);")
 	@Test
 	void overloaded_constructor_removed() {
 		var v1 = """
 			public class A {
 				public A(int i) {}
-				public A(float f) {}
+				public A(boolean b) {}
 			}""";
 		var v2 = """
 			public class A {

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldNoLongerStaticTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldNoLongerStaticTest.java
@@ -1,12 +1,16 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
+// §13.4.10
 class FieldNoLongerStaticTest {
+	@Client("int i = A.f;")
 	@Test
 	void field_no_longer_static() {
 		var v1 = """
@@ -19,5 +23,20 @@ class FieldNoLongerStaticTest {
 			}""";
 
 		assertBC("A.f", BreakingChangeKind.FIELD_NO_LONGER_STATIC, 2, buildDiff(v1, v2));
+	}
+
+	@Client("A a = new A();")
+	@Test
+	void private_field_no_longer_static() {
+		var v1 = """
+			public class A {
+				private static int f;
+			}""";
+		var v2 = """
+			public class A {
+				private int f = 0;
+			}""";
+
+		assertNoBC(buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldNowFinalTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldNowFinalTest.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class FieldNowFinalTest {
+	@Client("new A().f = 0;")
 	@Test
 	void field_now_final() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldNowStaticTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldNowStaticTest.java
@@ -1,12 +1,16 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
+// §13.4.10
 class FieldNowStaticTest {
+	@Client("int i = new A().f;")
 	@Test
 	void field_now_static() {
 		var v1 = """
@@ -19,5 +23,20 @@ class FieldNowStaticTest {
 			}""";
 
 		assertBC("A.f", BreakingChangeKind.FIELD_NOW_STATIC, 2, buildDiff(v1, v2));
+	}
+
+	@Client("A a = new A();")
+	@Test
+	void private_field_now_static() {
+		var v1 = """
+			public class A {
+				private int f;
+			}""";
+		var v2 = """
+			public class A {
+				private static int f = 0;
+			}""";
+
+		assertNoBC(buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldRemovedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class FieldRemovedTest {
+	@Client("int i = new B().f1;")
 	@Test
 	void leaked_public_field_now_private() {
 		var v1 = """
@@ -28,6 +30,7 @@ class FieldRemovedTest {
 		assertBC("A.f1", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new B().f1;")
 	@Test
 	void leaked_public_field_no_longer_leaked() {
 		var v1 = """
@@ -48,6 +51,7 @@ class FieldRemovedTest {
 		assertBC("A.f1", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().f;")
 	@Test
 	void public_field_removed() {
 		var v1 = """
@@ -59,6 +63,7 @@ class FieldRemovedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = A.f;")
 	@Test
 	void static_field_removed() {
 		var v1 = """
@@ -70,6 +75,7 @@ class FieldRemovedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().f;")
 	@Test
 	void field_now_hidden() {
 		var v1 = """
@@ -84,6 +90,7 @@ class FieldRemovedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().f;")
 	@Test
 	void field_now_initialized() {
 		var v1 = """
@@ -98,6 +105,12 @@ class FieldRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new A() {
+			void m() {
+				f = 0;
+			}
+		};""")
 	@Test
 	void field_visibility_protected_to_private() {
 		var v1 = """
@@ -112,6 +125,7 @@ class FieldRemovedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("// Can't test this one and, technically, is a BC")
 	@Test
 	void field_visibility_pkg_private_to_private() {
 		var v1 = """
@@ -126,6 +140,7 @@ class FieldRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().f;")
 	@Test
 	void field_visibility_public_to_protected() {
 		var v1 = """
@@ -142,6 +157,7 @@ class FieldRemovedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_NOW_PROTECTED, 2, diff);
 	}
 
+	@Client("E e = E.Y;")
 	@Test
 	void enum_constant_removed() {
 		var v1 = """
@@ -156,6 +172,7 @@ class FieldRemovedTest {
 		assertBC("E.Y", BreakingChangeKind.FIELD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("@A(A.E.Y) int i;")
 	@Test
 	void annotation_interface_enum_constant_removed() {
 		var v1 = """
@@ -172,6 +189,7 @@ class FieldRemovedTest {
 		assertBC("A$E.Y", BreakingChangeKind.FIELD_REMOVED, 3, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(0); // Can't test the field removed part specifically")
 	@Test
 	void record_field_removed() {
 		var v1 = "public record A(int i) {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldTypeChangedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -11,6 +12,7 @@ import static io.github.alien.roseau.utils.TestUtils.buildDiff;
  * To be refined once we distinguish binary vs source compatibility
  */
 class FieldTypeChangedTest {
+	@Client("int i = new A().f;")
 	@Test
 	void boxing() {
 		var v1 = """
@@ -25,6 +27,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("Integer i = new A().f;")
 	@Test
 	void unboxing() {
 		var v1 = """
@@ -39,6 +42,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().f;")
 	@Test
 	void widening() {
 		var v1 = """
@@ -53,6 +57,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("long l = new A().f;")
 	@Test
 	void narrowing() {
 		var v1 = """
@@ -67,6 +72,12 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new A().f = new java.io.InputStream() {
+			@Override public int read() {
+				return 0;
+			}
+		};""")
 	@Test
 	void subtype_jdk() {
 		var v1 = """
@@ -81,6 +92,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.FileInputStream fis = new A().f;")
 	@Test
 	void supertype_jdk() {
 		var v1 = """
@@ -95,6 +107,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().f = new I() {};")
 	@Test
 	void subtype_api() {
 		var v1 = """
@@ -113,6 +126,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("J j = new A().f;")
 	@Test
 	void supertype_api() {
 		var v1 = """
@@ -131,6 +145,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("I i = new A().f;")
 	@Test
 	void incompatible_api() {
 		var v1 = """
@@ -149,6 +164,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("Integer i = new A<Integer, String>().f;")
 	@Test
 	void incompatible_type_parameter() {
 		var v1 = """
@@ -163,6 +179,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A<java.util.HashMap, java.util.LinkedHashMap>().f = new java.util.HashMap<>();")
 	@Test
 	void subtype_type_parameter() {
 		var v1 = """
@@ -177,6 +194,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.LinkedHashMap m = new A<java.util.HashMap, java.util.LinkedHashMap>().f;")
 	@Test
 	void supertype_type_parameter() {
 		var v1 = """
@@ -191,6 +209,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.List<Integer> l = new A().f;")
 	@Test
 	void incompatible_generic() {
 		var v1 = """
@@ -205,6 +224,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.List<I> l = new A().f;")
 	@Test
 	void subtype_generic() {
 		var v1 = """
@@ -223,6 +243,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.List<J> l = new A().f;")
 	@Test
 	void supertype_generic() {
 		var v1 = """
@@ -241,6 +262,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int[] a = new A().f;")
 	@Test
 	void incompatible_array() {
 		var v1 = """
@@ -255,6 +277,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.InputStream[] a = new A().f;")
 	@Test
 	void subtype_array() {
 		var v1 = """
@@ -269,6 +292,7 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.FileInputStream[] a = new A().f;")
 	@Test
 	void supertype_array() {
 		var v1 = """
@@ -311,6 +335,10 @@ class FieldTypeChangedTest {
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		int i = I.f;
+		Object o = new C().f;
+		String s = new X().f;""")
 	@Test
 	void subtype_shadowing() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldTypeChangedTest.java
@@ -12,6 +12,34 @@ import static io.github.alien.roseau.utils.TestUtils.buildDiff;
  * To be refined once we distinguish binary vs source compatibility
  */
 class FieldTypeChangedTest {
+	@Test
+	void to_unknown() {
+		var v1 = """
+			public class A {
+				public A f;
+			}""";
+		var v2 = """
+			public class A {
+				public Unknown f;
+			}""";
+
+		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
+	}
+
+	@Test
+	void from_unknown() {
+		var v1 = """
+			public class A {
+				public Unknown f;
+			}""";
+		var v2 = """
+			public class A {
+				public A f;
+			}""";
+
+		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
+	}
+
 	@Client("int i = new A().f;")
 	@Test
 	void boxing() {
@@ -302,34 +330,6 @@ class FieldTypeChangedTest {
 		var v2 = """
 			public class A {
 				public java.io.InputStream[] f;
-			}""";
-
-		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
-	}
-
-	@Test
-	void to_unknown() {
-		var v1 = """
-			public class A {
-				public A f;
-			}""";
-		var v2 = """
-			public class A {
-				public Unknown f;
-			}""";
-
-		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
-	}
-
-	@Test
-	void from_unknown() {
-		var v1 = """
-			public class A {
-				public Unknown f;
-			}""";
-		var v2 = """
-			public class A {
-				public A f;
 			}""";
 
 		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));

--- a/core/src/test/java/io/github/alien/roseau/diff/FieldTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/FieldTypeChangedTest.java
@@ -12,34 +12,6 @@ import static io.github.alien.roseau.utils.TestUtils.buildDiff;
  * To be refined once we distinguish binary vs source compatibility
  */
 class FieldTypeChangedTest {
-	@Test
-	void to_unknown() {
-		var v1 = """
-			public class A {
-				public A f;
-			}""";
-		var v2 = """
-			public class A {
-				public Unknown f;
-			}""";
-
-		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
-	}
-
-	@Test
-	void from_unknown() {
-		var v1 = """
-			public class A {
-				public Unknown f;
-			}""";
-		var v2 = """
-			public class A {
-				public A f;
-			}""";
-
-		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
-	}
-
 	@Client("int i = new A().f;")
 	@Test
 	void boxing() {
@@ -363,5 +335,33 @@ class FieldTypeChangedTest {
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));
+	}
+
+	@Test
+	void to_unknown() {
+		var v1 = """
+			public class A {
+				public A f;
+			}""";
+		var v2 = """
+			public class A {
+				public Unknown f;
+			}""";
+
+		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
+	}
+
+	@Test
+	void from_unknown() {
+		var v1 = """
+			public class A {
+				public Unknown f;
+			}""";
+		var v2 = """
+			public class A {
+				public A f;
+			}""";
+
+		assertBC("A.f", BreakingChangeKind.FIELD_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/JezekTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/JezekTest.java
@@ -7,6 +7,9 @@ import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
+/**
+ * Should check for overlaps and merge them with "regular" tests
+ */
 class JezekTest {
 	@Test
 	void genericsWildcardsClazzConstructorParamLowerBoundsAdd() {

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodAbstractAddedToClassTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodAbstractAddedToClassTest.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodAbstractAddedToClassTest {
+	@Client("A a = new A() {};")
 	@Test
 	void method_abstract_added_to_class() {
 		var v1 = "public abstract class A {}";
@@ -18,6 +20,7 @@ class MethodAbstractAddedToClassTest {
 		assertBC("A", BreakingChangeKind.METHOD_ABSTRACT_ADDED_TO_CLASS, 1, buildDiff(v1, v2));
 	}
 
+	@Client("B b = new B() {};")
 	@Test
 	void method_abstract_added_to_class_indirect() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodAddedToInterfaceTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodAddedToInterfaceTest.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodAddedToInterfaceTest {
+	@Client("I i = new I() {};")
 	@Test
 	void method_added_to_interface() {
 		var v1 = "public interface I {}";
@@ -18,6 +20,7 @@ class MethodAddedToInterfaceTest {
 		assertBC("I", BreakingChangeKind.METHOD_ADDED_TO_INTERFACE, 1, buildDiff(v1, v2));
 	}
 
+	@Client("J j = new J() {};")
 	@Test
 	void method_added_to_interface_indirect() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodFormalTypeParameterAddedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodFormalTypeParameterAddedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodFormalTypeParameterAddedTest {
+	@Client("new A().m();")
 	@Test
 	void first_param_added() {
 		var v1 = """
@@ -22,6 +24,7 @@ class MethodFormalTypeParameterAddedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("new A().<String>m();")
 	@Test
 	void second_param_added() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodFormalTypeParameterRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodFormalTypeParameterRemovedTest.java
@@ -1,12 +1,14 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodFormalTypeParameterRemovedTest {
+	@Client("new A().<String>m();")
 	@Test
 	void first_param_removed() {
 		var v1 = """
@@ -21,6 +23,7 @@ class MethodFormalTypeParameterRemovedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_FORMAL_TYPE_PARAMETERS_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().<String, Integer>m();")
 	@Test
 	void second_param_removed() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodLessAccessibleTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodLessAccessibleTest.java
@@ -1,14 +1,17 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodLessAccessibleTest {
+	@Client("new A().m();")
 	@Test
-	void method_now_protected() {
+	void public_to_protected() {
 		var v1 = """
 			public class A {
 				public void m() {}
@@ -19,5 +22,38 @@ class MethodLessAccessibleTest {
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_PROTECTED, 2, buildDiff(v1, v2));
+	}
+
+	@Client("""
+		new A() {
+			@Override protected void m() {}
+		};""")
+	@Test
+	void protected_to_package_private() {
+		var v1 = """
+			public class A {
+				protected void m() {}
+			}""";
+		var v2 = """
+			public class A {
+				void m() {}
+			}""";
+
+		assertBC("A.m", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
+	}
+
+	@Client("A a = new A();")
+	@Test
+	void package_private_to_private() {
+		var v1 = """
+			public class A {
+				void m() {}
+			}""";
+		var v2 = """
+			public class A {
+				private void m() {}
+			}""";
+
+		assertNoBC(buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNoLongerStaticTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNoLongerStaticTest.java
@@ -1,12 +1,16 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
+// §13.4.19
 class MethodNoLongerStaticTest {
+	@Client("A.m();")
 	@Test
 	void method_no_longer_static() {
 		var v1 = """
@@ -19,5 +23,20 @@ class MethodNoLongerStaticTest {
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_NO_LONGER_STATIC, 2, buildDiff(v1, v2));
+	}
+
+	@Client("A a = new A();")
+	@Test
+	void private_method_no_longer_static() {
+		var v1 = """
+			public class A {
+				private static void m() {}
+			}""";
+		var v2 = """
+			public class A {
+				private void m() {}
+			}""";
+
+		assertNoBC(buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNoLongerVarargsTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNoLongerVarargsTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodNoLongerVarargsTest {
+	@Client("new A().m(1, 2);")
 	@Test
 	void method_no_longer_varargs_first() {
 		var v1 = """
@@ -22,36 +24,41 @@ class MethodNoLongerVarargsTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().m(null, 1, 2);")
 	@Test
 	void method_no_longer_varargs_last() {
 		var v1 = """
 			public class A {
-				public void m(String s, int... i) {}
+				public void m(Object o, int... i) {}
 			}""";
 		var v2 = """
 			public class A {
-				public void m(String s, int i) {}
+				public void m(Object o, int i) {}
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new A().m(0);
+		new A().m(1, 2);""")
 	@Test
 	void method_overloaded_varargs() {
 		var v1 = """
 			public class A {
-				public void m(String s) {}
-				public void m(String... s) {}
+				public void m(int i) {}
+				public void m(int... i) {}
 			}""";
 		var v2 = """
 			public class A {
-				public void m(String s) {}
-				public void m(String... s) {}
+				public void m(int i) {}
+				public void m(int... i) {}
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(1, 2);")
 	@Test
 	void constructor_no_longer_varargs_first() {
 		var v1 = """
@@ -66,31 +73,35 @@ class MethodNoLongerVarargsTest {
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("A a = new A(null, 1, 2);")
 	@Test
 	void constructor_no_longer_varargs_last() {
 		var v1 = """
 			public class A {
-				public A(String s, int... i) {}
+				public A(Object o, int... i) {}
 			}""";
 		var v2 = """
 			public class A {
-				public A(String s, int i) {}
+				public A(Object o, int i) {}
 			}""";
 
 		assertBC("A.<init>", BreakingChangeKind.CONSTRUCTOR_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		A a1 = new A(0);
+		A a2 = new A(1, 2);""")
 	@Test
 	void constructor_overloaded_varargs() {
 		var v1 = """
 			public class A {
-				public A(String s) {}
-				public A(String... s) {}
+				public A(int i) {}
+				public A(int... i) {}
 			}""";
 		var v2 = """
 			public class A {
-				public A(String s) {}
-				public A(String... s) {}
+				public A(int i) {}
+				public A(int... i) {}
 			}""";
 
 		assertNoBC(buildDiff(v1, v2));

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNowAbstractTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNowAbstractTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodNowAbstractTest {
+	@Client("new A(){};")
 	@Test
 	void method_now_abstract() {
 		var v1 = """
@@ -22,6 +24,7 @@ class MethodNowAbstractTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_ABSTRACT, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new I(){};")
 	@Test
 	void default_now_abstract() {
 		var v1 = """
@@ -36,6 +39,10 @@ class MethodNowAbstractTest {
 		assertBC("I.m", BreakingChangeKind.METHOD_NOW_ABSTRACT, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new I() {
+			@Override public void m() {}
+		};""")
 	@Test
 	void implicitly_abstract_to_abstract() {
 		var v1 = """
@@ -50,42 +57,44 @@ class MethodNowAbstractTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("new B(){};")
 	@Test
 	void method_becomes_abstract_in_superclass_affecting_subclass() {
 		var v1 = """
-      public abstract class A {
-        public void m() {}
-      }
-      public class B extends A {}""";
+			public abstract class A {
+			  public void m() {}
+			}
+			public class B extends A {}""";
 
 		var v2 = """
-      public abstract class A {
-        public abstract void m();
-      }
-      public class B extends A {
-        public void m() {}
-      }""";
+			public abstract class A {
+			  public abstract void m();
+			}
+			public class B extends A {
+			  public void m() {}
+			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_ABSTRACT, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A(){};")
 	@Test
 	void abstract_class_implements_interface_method_as_abstract() {
 		var v1 = """
-      public interface I {
-        void m();
-      }
-      public abstract class A implements I {
-        public void m() {}
-      }""";
+			public interface I {
+			  void m();
+			}
+			public abstract class A implements I {
+			  public void m() {}
+			}""";
 
 		var v2 = """
-      public interface I {
-        void m();
-      }
-      public abstract class A implements I {
-        public abstract void m();
-      }""";
+			public interface I {
+			  void m();
+			}
+			public abstract class A implements I {
+			  public abstract void m();
+			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_ABSTRACT, 2, buildDiff(v1, v2));
 	}

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNowAbstractTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNowAbstractTest.java
@@ -57,7 +57,7 @@ class MethodNowAbstractTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
-	@Client("new B(){};")
+	@Client("new A(){};")
 	@Test
 	void method_becomes_abstract_in_superclass_affecting_subclass() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNowFinalTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNowFinalTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodNowFinalTest {
+	@Client("new A() { @Override public void m() {} };")
 	@Test
 	void method_now_final() {
 		var v1 = """
@@ -22,6 +24,7 @@ class MethodNowFinalTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_FINAL, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A();")
 	@Test
 	void method_now_final_in_final_class() {
 		var v1 = """
@@ -36,6 +39,7 @@ class MethodNowFinalTest {
 		assertNoBC(BreakingChangeKind.METHOD_NOW_FINAL, buildDiff(v1, v2));
 	}
 
+	@Client("new A();")
 	@Test
 	void method_now_final_in_effectively_final_class() {
 		var v1 = """
@@ -52,6 +56,7 @@ class MethodNowFinalTest {
 		assertNoBC(BreakingChangeKind.METHOD_NOW_FINAL, buildDiff(v1, v2));
 	}
 
+	@Client("new B() { @Override public void m() {} };")
 	@Test
 	void method_now_final_in_subclass() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNowFinalTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNowFinalTest.java
@@ -39,7 +39,7 @@ class MethodNowFinalTest {
 		assertNoBC(BreakingChangeKind.METHOD_NOW_FINAL, buildDiff(v1, v2));
 	}
 
-	@Client("new A();")
+	@Client("// No uses")
 	@Test
 	void method_now_final_in_effectively_final_class() {
 		var v1 = """

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNowStaticTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNowStaticTest.java
@@ -1,12 +1,16 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
+// §13.4.19
 class MethodNowStaticTest {
+	@Client("new A().m();")
 	@Test
 	void method_now_static() {
 		var v1 = """
@@ -19,5 +23,20 @@ class MethodNowStaticTest {
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_STATIC, 2, buildDiff(v1, v2));
+	}
+
+	@Client("A a = new A();")
+	@Test
+	void private_method_now_static() {
+		var v1 = """
+			public class A {
+				private void m() {}
+			}""";
+		var v2 = """
+			public class A {
+				private static void m() {}
+			}""";
+
+		assertNoBC(buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodNowThrowsCheckedExceptionTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodNowThrowsCheckedExceptionTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodNowThrowsCheckedExceptionTest {
+	@Client("new A().m();")
 	@Test
 	void method_now_throws() {
 		var v1 = """
@@ -22,6 +24,7 @@ class MethodNowThrowsCheckedExceptionTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new B().m();")
 	@Test
 	void method_now_throws_indirect() {
 		var v1 = """
@@ -38,6 +41,7 @@ class MethodNowThrowsCheckedExceptionTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new B().m();")
 	@Test
 	void method_now_throws_indirect_with_override_without_throws() {
 		var v1 = """
@@ -58,43 +62,56 @@ class MethodNowThrowsCheckedExceptionTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		try {
+			new A().m();
+		} catch (java.io.IOException e) {}""")
 	@Test
 	void method_now_throws_unchecked() {
 		var v1 = """
 			public class A {
-				public void m() throws Exception {}
+				public void m() throws java.io.IOException {}
 			}""";
 		var v2 = """
 			public class A {
 				public void m() throws IllegalArgumentException {}
 			}""";
 
+		assertBC("A.m", BreakingChangeKind.METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION, 2, buildDiff(v1, v2));
 		assertNoBC(BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		try {
+			new A().m();
+		} catch (java.io.IOException e) {}""")
 	@Test
 	void method_now_throws_subtype() {
 		var v1 = """
 			public class A {
-				public void m() throws Exception {}
+				public void m() throws java.io.IOException {}
 			}""";
 		var v2 = """
 			public class A {
-				public void m() throws java.io.IOException {}
+				public void m() throws java.io.ObjectStreamException {}
 			}""";
 
 		assertNoBC(BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		try {
+			new A().m();
+		} catch (java.io.ObjectStreamException e) {}""")
 	@Test
 	void method_now_throws_supertype() {
 		var v1 = """
 			public class A {
-				public void m() throws java.io.IOException {}
+				public void m() throws java.io.ObjectStreamException {}
 			}""";
 		var v2 = """
 			public class A {
-				public void m() throws Exception {}
+				public void m() throws java.io.IOException {}
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_NOW_THROWS_CHECKED_EXCEPTION, 2, buildDiff(v1, v2));

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodRemovedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class MethodRemovedTest {
+	@Client("new B().m1();")
 	@Test
 	void leaked_public_method_now_private() {
 		var v1 = """
@@ -28,6 +30,7 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new B().m1();")
 	@Test
 	void leaked_public_method_no_longer_leaked() {
 		var v1 = """
@@ -48,6 +51,7 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().m1();")
 	@Test
 	void public_method_removed() {
 		var v1 = """
@@ -59,6 +63,7 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().m1(0);")
 	@Test
 	void overloaded_method_removed() {
 		var v1 = """
@@ -74,6 +79,7 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 3, buildDiff(v1, v2));
 	}
 
+	@Client("A.m1();")
 	@Test
 	void static_method_removed() {
 		var v1 = """
@@ -85,6 +91,7 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new I(){}.m1();")
 	@Test
 	void default_method_removed_in_interface() {
 		var v1 = """
@@ -96,6 +103,7 @@ class MethodRemovedTest {
 		assertBC("I.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().m1();")
 	@Test
 	void method_visibility_reduced_from_public_to_package_private() {
 		var v1 = """
@@ -110,6 +118,7 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new B().m1();")
 	@Test
 	void overridden_method_removed_from_subclass() {
 		var v1 = """
@@ -128,6 +137,7 @@ class MethodRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("new A().m1();")
 	@Test
 	void interface_method_removed_affecting_implementer() {
 		var v1 = """
@@ -144,11 +154,12 @@ class MethodRemovedTest {
 		assertBC("I.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().m1(0, null);")
 	@Test
 	void method_parameters_changed() {
 		var v1 = """
 			public class A {
-			    public void m1(int x, String y) {}
+			    public void m1(int x, Object y) {}
 			}""";
 		var v2 = """
 			public class A {
@@ -158,6 +169,10 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new A() {
+			@Override protected void m1() {}
+		};""")
 	@Test
 	void method_visibility_protected_to_private() {
 		var v1 = """
@@ -172,31 +187,34 @@ class MethodRemovedTest {
 		assertBC("A.m1", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A().m(null, 1);")
 	@Test
 	void method_now_varargs() {
 		var v1 = """
 			public class A {
-			    public void m(String s, int i) {}
+			    public void m(Object o, int i) {}
 			}""";
 		var v2 = """
 			public class A {
-			    public void m(String s, int... i) {}
+			    public void m(Object o, int... i) {}
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("@A(0) int i;")
 	@Test
 	void annotation_method_removed() {
 		var v1 = """
 			public @interface A {
-				String value();
+				int value();
 			}""";
 		var v2 = "public @interface A {}";
 
 		assertBC("A.value", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A(0).m();")
 	@Test
 	void record_method_removed() {
 		var v1 = """
@@ -210,6 +228,7 @@ class MethodRemovedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("new A(0, 0f); // Can't really test f()")
 	@Test
 	void record_getter_removed() {
 		var v1 = "public record A(int i, float f) {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/MethodReturnTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/MethodReturnTypeChangedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -11,6 +12,7 @@ import static io.github.alien.roseau.utils.TestUtils.buildDiff;
  * they all map to a simple METHOD_RETURN_TYPE_CHANGED.
  */
 class MethodReturnTypeChangedTest {
+	@Client("new A().m();")
 	@Test
 	void void_to_non_void() {
 		var v1 = """
@@ -25,20 +27,22 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().m();")
 	@Test
 	void non_void_to_void() {
 		var v1 = """
 			public class A {
-				public void m() {}
+				public int m() { return 0; }
 			}""";
 		var v2 = """
 			public class A {
-				public int m() { return 0; }
+				public void m() {}
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().m();")
 	@Test
 	void boxing() {
 		var v1 = """
@@ -53,6 +57,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("Integer i = new A().m();")
 	@Test
 	void unboxing() {
 		var v1 = """
@@ -67,6 +72,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int i = new A().m();")
 	@Test
 	void widening() {
 		var v1 = """
@@ -81,6 +87,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("long l = new A().m();")
 	@Test
 	void narrowing() {
 		var v1 = """
@@ -95,6 +102,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.InputStream is = new A().m();")
 	@Test
 	void subtype_jdk() {
 		var v1 = """
@@ -109,6 +117,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.FileInputStream fis = new A().m();")
 	@Test
 	void supertype_jdk() {
 		var v1 = """
@@ -123,6 +132,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("I i = new A().m();")
 	@Test
 	void subtype_api() {
 		var v1 = """
@@ -141,6 +151,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("J j = new A().m();")
 	@Test
 	void supertype_api() {
 		var v1 = """
@@ -159,6 +170,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("I i = new A().m();")
 	@Test
 	void incompatible_api() {
 		var v1 = """
@@ -177,6 +189,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("Integer i = new A<Integer, String>().m();")
 	@Test
 	void incompatible_type_parameter() {
 		var v1 = """
@@ -191,6 +204,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("CharSequence cs = new A<CharSequence, String>().m();")
 	@Test
 	void subtype_type_parameter() {
 		var v1 = """
@@ -205,6 +219,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("String s = new A<CharSequence, String>().m();")
 	@Test
 	void supertype_type_parameter() {
 		var v1 = """
@@ -219,6 +234,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.List<Integer> l = new A().m();")
 	@Test
 	void incompatible_generic() {
 		var v1 = """
@@ -233,6 +249,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.List<I> l = new A().m();")
 	@Test
 	void subtype_generic() {
 		var v1 = """
@@ -251,6 +268,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.util.List<J> l = new A().m();")
 	@Test
 	void supertype_generic() {
 		var v1 = """
@@ -269,6 +287,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("int[] a = new A().m();")
 	@Test
 	void incompatible_array() {
 		var v1 = """
@@ -283,6 +302,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.InputStream[] a = new A().m();")
 	@Test
 	void subtype_array() {
 		var v1 = """
@@ -297,6 +317,7 @@ class MethodReturnTypeChangedTest {
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("java.io.FileInputStream[] a = new A().m();")
 	@Test
 	void supertype_array() {
 		var v1 = """
@@ -309,6 +330,21 @@ class MethodReturnTypeChangedTest {
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
+	}
+
+	@Client("@A(0) class X {}")
+	@Test
+	void annotation_interface_method() {
+		var v1 = """
+			public @interface A {
+				int value();
+			}""";
+		var v2 = """
+			public @interface A {
+				String value();
+			}""";
+
+		assertBC("A.value", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 
 	@Test
@@ -337,19 +373,5 @@ class MethodReturnTypeChangedTest {
 			}""";
 
 		assertBC("A.m", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
-	}
-
-	@Test
-	void annotation_interface_method() {
-		var v1 = """
-			public @interface A {
-				int value();
-			}""";
-		var v2 = """
-			public @interface A {
-				String value();
-			}""";
-
-		assertBC("A.value", BreakingChangeKind.METHOD_RETURN_TYPE_CHANGED, 2, buildDiff(v1, v2));
 	}
 }

--- a/core/src/test/java/io/github/alien/roseau/diff/NestedClassNoLongerStaticTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/NestedClassNoLongerStaticTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class NestedClassNoLongerStaticTest {
+	@Client("A.B b = new A.B();")
 	@Test
 	void nested_class_no_longer_static() {
 		var v1 = "public class A { public static class B {} }";
@@ -16,6 +18,7 @@ class NestedClassNoLongerStaticTest {
 		assertBC("A$B", BreakingChangeKind.NESTED_CLASS_NO_LONGER_STATIC, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A.B.C c = new A.B.C();")
 	@Test
 	void doubly_nested_class_no_longer_static() {
 		var v1 = "public class A { public class B { public static class C {} } }";
@@ -24,6 +27,7 @@ class NestedClassNoLongerStaticTest {
 		assertBC("A$B$C", BreakingChangeKind.NESTED_CLASS_NO_LONGER_STATIC, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A.B b = new A.B();")
 	@Test
 	void nested_class_in_interface_no_longer_static() {
 		var v1 = "public interface A { public static class B {} }";
@@ -32,6 +36,7 @@ class NestedClassNoLongerStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Classes nested within interfaces are implicitly static
 	}
 
+	@Client("A.B b = new A.B(){};")
 	@Test
 	void nested_interface_no_longer_static() {
 		var v1 = "public class A { public static interface B {} }";
@@ -40,6 +45,7 @@ class NestedClassNoLongerStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Nested interfaces are implicitly static
 	}
 
+	@Client("A.B b;")
 	@Test
 	void nested_enum_no_longer_static() {
 		var v1 = "public class A { public static enum B {} }";
@@ -48,6 +54,7 @@ class NestedClassNoLongerStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Enums nested within classes are implicitly static
 	}
 
+	@Client("@A.B int i;")
 	@Test
 	void nested_annotation_no_longer_static() {
 		var v1 = "public class A { public static @interface B {} }";
@@ -56,6 +63,7 @@ class NestedClassNoLongerStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Annotations nested within classes are implicitly static
 	}
 
+	@Client("A.B b = new A.B();")
 	@Test
 	void nested_record_no_longer_static() {
 		var v1 = "public class A { public static record B() {} }";

--- a/core/src/test/java/io/github/alien/roseau/diff/NestedClassNowStaticTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/NestedClassNowStaticTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class NestedClassNowStaticTest {
+	@Client("new A().new B();")
 	@Test
 	void nested_class_now_static() {
 		var v1 = "public class A { public class B {} }";
@@ -16,6 +18,7 @@ class NestedClassNowStaticTest {
 		assertBC("A$B", BreakingChangeKind.NESTED_CLASS_NOW_STATIC, 1, buildDiff(v1, v2));
 	}
 
+	@Client("new A().new B().new C();")
 	@Test
 	void doubly_nested_class_now_static() {
 		var v1 = "public class A { public class B { public class C {} } }";
@@ -24,6 +27,7 @@ class NestedClassNowStaticTest {
 		assertBC("A$B$C", BreakingChangeKind.NESTED_CLASS_NOW_STATIC, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A.B b;")
 	@Test
 	void nested_class_in_interface_now_static() {
 		var v1 = "public interface A { public class B {} }";
@@ -32,6 +36,7 @@ class NestedClassNowStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Classes nested within interfaces are implicitly static
 	}
 
+	@Client("A.B b;")
 	@Test
 	void nested_interface_now_static() {
 		var v1 = "public class A { public interface B {} }";
@@ -40,6 +45,7 @@ class NestedClassNowStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Nested interfaces are implicitly static
 	}
 
+	@Client("A.B b;")
 	@Test
 	void nested_enum_now_static() {
 		var v1 = "public class A { public enum B {} }";
@@ -48,6 +54,7 @@ class NestedClassNowStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Enums nested within classes are implicitly static
 	}
 
+	@Client("@A.B int a;")
 	@Test
 	void nested_annotation_now_static() {
 		var v1 = "public class A { public @interface B {} }";
@@ -56,6 +63,7 @@ class NestedClassNowStaticTest {
 		assertNoBC(buildDiff(v1, v2)); // Annotations nested within classes are implicitly static
 	}
 
+	@Client("A.B b;")
 	@Test
 	void nested_record_now_static() {
 		var v1 = "public class A { public record B() {} }";

--- a/core/src/test/java/io/github/alien/roseau/diff/SuperTypeRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/SuperTypeRemovedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,11 +9,12 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class SuperTypeRemovedTest {
+	@Client("B b = new B(); // Can't upcast (A)")
 	@Test
 	void private_superclass_removed() {
 		var v1 = """
-      class A {}
-      public class B extends A {}""";
+			class A {}
+			public class B extends A {}""";
 		var v2 = """
 			class A {}
 			public class B {}""";
@@ -20,11 +22,12 @@ class SuperTypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A b = new B();")
 	@Test
 	void public_superclass_removed() {
 		var v1 = """
-      public class A {}
-      public class B extends A {}""";
+			public class A {}
+			public class B extends A {}""";
 		var v2 = """
 			public class A {}
 			public class B {}""";
@@ -32,12 +35,13 @@ class SuperTypeRemovedTest {
 		assertBC("B", BreakingChangeKind.SUPERTYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("B c = new C(); // Can't upcast (A)")
 	@Test
 	void private_superclass_removed_indirect() {
 		var v1 = """
-      class A {}
-      public class B extends A {}
-      public class C extends B {}""";
+			class A {}
+			public class B extends A {}
+			public class C extends B {}""";
 		var v2 = """
 			class A {}
 			public class B {}
@@ -46,12 +50,13 @@ class SuperTypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A c = new C();")
 	@Test
 	void public_superclass_removed_indirect() {
 		var v1 = """
-      public class A {}
-      class B extends A {}
-      public class C extends B {}""";
+			public class A {}
+			class B extends A {}
+			public class C extends B {}""";
 		var v2 = """
 			public class A {}
 			class B {}
@@ -60,11 +65,12 @@ class SuperTypeRemovedTest {
 		assertBC("C", BreakingChangeKind.SUPERTYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("B b = new B(); // Can't upcast (A)")
 	@Test
 	void private_interface_removed() {
 		var v1 = """
-      interface A {}
-      public class B implements A {}""";
+			interface A {}
+			public class B implements A {}""";
 		var v2 = """
 			interface A {}
 			public class B {}""";
@@ -72,11 +78,12 @@ class SuperTypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A b = new B();")
 	@Test
 	void public_interface_removed() {
 		var v1 = """
-      public interface A {}
-      public class B implements A {}""";
+			public interface A {}
+			public class B implements A {}""";
 		var v2 = """
 			public interface A {}
 			public class B {}""";
@@ -84,12 +91,13 @@ class SuperTypeRemovedTest {
 		assertBC("B", BreakingChangeKind.SUPERTYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("B c = new C(); // Can't upcast (A)")
 	@Test
 	void private_interface_removed_indirect() {
 		var v1 = """
-      interface A {}
-      public class B implements A {}
-      public class C extends B {}""";
+			interface A {}
+			public class B implements A {}
+			public class C extends B {}""";
 		var v2 = """
 			interface A {}
 			public class B {}
@@ -98,12 +106,13 @@ class SuperTypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A c = new C();")
 	@Test
 	void public_interface_removed_indirect() {
 		var v1 = """
-      public interface A {}
-      class B implements A {}
-      public class C extends B {}""";
+			public interface A {}
+			class B implements A {}
+			public class C extends B {}""";
 		var v2 = """
 			public interface A {}
 			class B {}
@@ -112,16 +121,17 @@ class SuperTypeRemovedTest {
 		assertBC("C", BreakingChangeKind.SUPERTYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A c = new C(){};")
 	@Test
 	void public_interface_extended_removed_indirect() {
 		var v1 = """
-      public interface A {}
-      interface B extends A {}
-      public interface C extends B {}""";
+			public interface A {}
+			interface B extends A {}
+			public interface C extends B {}""";
 		var v2 = """
-      public interface A {}
-      interface B {}
-      public interface C extends B {}""";
+			public interface A {}
+			interface B {}
+			public interface C extends B {}""";
 
 		assertBC("C", BreakingChangeKind.SUPERTYPE_REMOVED, 1, buildDiff(v1, v2));
 	}

--- a/core/src/test/java/io/github/alien/roseau/diff/TypeFormalTypeParameterAddedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/TypeFormalTypeParameterAddedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class TypeFormalTypeParameterAddedTest {
+	@Client("A a;")
 	@Test
 	void first_param_added() {
 		var v1 = "public class A {}";
@@ -16,6 +18,7 @@ class TypeFormalTypeParameterAddedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<String> a;")
 	@Test
 	void second_param_added() {
 		var v1 = "public class A<T> {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/TypeFormalTypeParameterChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/TypeFormalTypeParameterChangedTest.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class TypeFormalTypeParameterChangedTest {
+	@Client("A<String> a = new A<>();")
 	@Test
 	void param_renamed() {
 		var v1 = "public class A<T> {}";
@@ -16,6 +18,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<String, Integer> a = new A<>();")
 	@Test
 	void param_swapped() {
 		var v1 = "public class A<T, U> {}";
@@ -24,6 +27,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<String, CharSequence> a = new A<>();")
 	@Test
 	void bounded_param_swapped() {
 		var v1 = "public class A<T extends String, U extends CharSequence> {}";
@@ -32,6 +36,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<Object> a = new A<>();")
 	@Test
 	void bound_added() {
 		var v1 = "public class A<T> {}";
@@ -40,6 +45,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<Object> a = new A<>();")
 	@Test
 	void bound_object_added() {
 		var v1 = "public class A<T> {}";
@@ -48,6 +54,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<String> a = new A<>();")
 	@Test
 	void bound_removed() {
 		var v1 = "public class A<T extends String> {}";
@@ -56,6 +63,10 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("""
+		abstract class X implements CharSequence, Runnable {}
+		A<X> a = new A<>();
+		""")
 	@Test
 	void second_bound_removed() {
 		var v1 = "public class A<T extends CharSequence & Runnable> {}";
@@ -64,6 +75,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<String, CharSequence> a = new A<>();")
 	@Test
 	void bound_param_removed() {
 		var v1 = "public class A<T extends U, U> {}";
@@ -72,6 +84,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<Integer, Number> a = new A<>();")
 	@Test
 	void bound_param_added() {
 		var v1 = "public class A<T, U> {}";
@@ -80,6 +93,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<String> a = new A<>();")
 	@Test
 	void bound_modified_compatible() {
 		var v1 = "public class A<T extends String> {}";
@@ -88,6 +102,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<StringBuilder> a = new A<>();")
 	@Test
 	void bound_modified_incompatible() {
 		var v1 = "public class A<T extends CharSequence> {}";
@@ -96,6 +111,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<String, StringBuilder, String> a = new A<>();")
 	@Test
 	void bound_modified_incompatible_param_1() {
 		// Still breaking if client chooses a U that is not a subtype of T
@@ -105,6 +121,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<String, CharSequence, CharSequence> a = new A<>();")
 	@Test
 	void bound_modified_incompatible_param_2() {
 		var v1 = "public class A<T extends String, U extends CharSequence, V extends U> {}";
@@ -113,6 +130,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<String> a = new A<>();")
 	@Test
 	void second_bound_added_compatible() {
 		var v1 = "public class A<T extends String> {}";
@@ -121,6 +139,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<String> a = new A<>();")
 	@Test
 	void second_bound_added_incompatible() {
 		var v1 = "public class A<T extends String> {}";
@@ -129,6 +148,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_changed_to_compatible_generic() {
 		var v1 = "public class A<T extends java.util.List<? extends String>> {}";
@@ -137,6 +157,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<CharSequence>> a = new A<>();")
 	@Test
 	void bound_changed_to_incompatible_generic() {
 		var v1 = "public class A<T extends java.util.List<? extends CharSequence>> {}";
@@ -145,6 +166,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.ArrayList<String>> a = new A<>();")
 	@Test
 	void bound_changed_to_generic_supertype() {
 		var v1 = "public class A<T extends java.util.ArrayList<? extends String>> {}";
@@ -153,6 +175,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_changed_to_generic_subtype() {
 		var v1 = "public class A<T extends java.util.List<? extends String>> {}";
@@ -161,6 +184,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<CharSequence>> a = new A<>();")
 	@Test
 	void bound_changed_to_compatible_generic_super() {
 		var v1 = "public class A<T extends java.util.List<? super CharSequence>> {}";
@@ -169,6 +193,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_changed_to_incompatible_generic_super() {
 		var v1 = "public class A<T extends java.util.List<? super String>> {}";
@@ -177,6 +202,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.ArrayList<CharSequence>> a = new A<>();")
 	@Test
 	void bound_changed_to_incompatible_type_super() {
 		var v1 = "public class A<T extends java.util.ArrayList<? super CharSequence>> {}";
@@ -185,6 +211,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<CharSequence>> a = new A<>();")
 	@Test
 	void bound_changed_to_incompatible_subtype_super() {
 		var v1 = "public class A<T extends java.util.List<? super CharSequence>> {}";
@@ -193,6 +220,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_changed_to_generic_wildcard_extends() {
 		var v1 = "public class A<T extends java.util.List<? extends CharSequence>> {}";
@@ -201,6 +229,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<Object>> a = new A<>();")
 	@Test
 	void bound_changed_from_generic_wildcard_extends() {
 		var v1 = "public class A<T extends java.util.List<?>> {}";
@@ -209,6 +238,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<Object>> a = new A<>();")
 	@Test
 	void bound_changed_to_generic_wildcard_super() {
 		var v1 = "public class A<T extends java.util.List<? super CharSequence>> {}";
@@ -217,6 +247,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_changed_from_generic_wildcard_super() {
 		var v1 = "public class A<T extends java.util.List<?>> {}";
@@ -225,6 +256,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_generic_wildcard_to_type() {
 		var v1 = "public class A<T extends java.util.List<? extends CharSequence>> {}";
@@ -233,6 +265,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<String>> a = new A<>();")
 	@Test
 	void bound_type_to_compatible_wildcard() {
 		var v1 = "public class A<T extends java.util.List<String>> {}";
@@ -241,6 +274,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<CharSequence>> a = new A<>();")
 	@Test
 	void bound_type_to_incompatible_wildcard() {
 		var v1 = "public class A<T extends java.util.List<CharSequence>> {}";
@@ -249,6 +283,7 @@ class TypeFormalTypeParameterChangedTest {
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_CHANGED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<java.util.List<CharSequence>, String> a = new A();")
 	@Test
 	void unchanged_type_params_bounds() {
 		var v1 = "public class A<T extends java.util.List<? super U>, U> {}";

--- a/core/src/test/java/io/github/alien/roseau/diff/TypeFormalTypeParameterRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/TypeFormalTypeParameterRemovedTest.java
@@ -1,22 +1,25 @@
 package io.github.alien.roseau.diff;
 
 import io.github.alien.roseau.diff.changes.BreakingChangeKind;
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.utils.TestUtils.assertBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class TypeFormalTypeParameterRemovedTest {
+	@Client("A<String> a;")
 	@Test
-	void first_param_added() {
+	void first_param_removed() {
 		var v1 = "public class A<T> {}";
 		var v2 = "public class A {}";
 
 		assertBC("A", BreakingChangeKind.TYPE_FORMAL_TYPE_PARAMETERS_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A<String, String> a;")
 	@Test
-	void second_param_added() {
+	void second_param_removed() {
 		var v1 = "public class A<T, U> {}";
 		var v2 = "public class A<T> {}";
 

--- a/core/src/test/java/io/github/alien/roseau/diff/TypeNowProtectedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/TypeNowProtectedTest.java
@@ -1,13 +1,14 @@
 package io.github.alien.roseau.diff;
 
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
-import static io.github.alien.roseau.utils.TestUtils.assertBC;
-import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
-import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 import static io.github.alien.roseau.diff.changes.BreakingChangeKind.TYPE_NOW_PROTECTED;
+import static io.github.alien.roseau.utils.TestUtils.assertBC;
+import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class TypeNowProtectedTest {
+	@Client("A.B b;")
 	@Test
 	void public_nested_type_now_protected() {
 		var v1 = "public class A { public class B {} }";

--- a/core/src/test/java/io/github/alien/roseau/diff/TypeRemovedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/TypeRemovedTest.java
@@ -1,5 +1,6 @@
 package io.github.alien.roseau.diff;
 
+import io.github.alien.roseau.utils.Client;
 import org.junit.jupiter.api.Test;
 
 import static io.github.alien.roseau.diff.changes.BreakingChangeKind.TYPE_REMOVED;
@@ -8,6 +9,7 @@ import static io.github.alien.roseau.utils.TestUtils.assertNoBC;
 import static io.github.alien.roseau.utils.TestUtils.buildDiff;
 
 class TypeRemovedTest {
+	@Client("// Cannot write client code")
 	@Test
 	void class_private_removed() {
 		var v1 = "class A {}";
@@ -16,14 +18,16 @@ class TypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A a;")
 	@Test
 	void class_public_removed() {
 		var v1 = "public class A {}";
-		var v2 = "public class B {}";
+		var v2 = "";
 
 		assertBC("A", TYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a;")
 	@Test
 	void class_public_kept() {
 		var v1 = "public class A {}";
@@ -32,6 +36,7 @@ class TypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("A a;")
 	@Test
 	void class_public_moved() {
 		var v1 = "public class A {}";
@@ -40,6 +45,7 @@ class TypeRemovedTest {
 		assertBC("A", TYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a;")
 	@Test
 	void class_now_package_private() {
 		var v1 = "public class A {}";
@@ -48,6 +54,7 @@ class TypeRemovedTest {
 		assertBC("A", TYPE_REMOVED, 1, buildDiff(v1, v2));
 	}
 
+	@Client("A a; // Cannot access A.I")
 	@Test
 	void class_inner_private_in_class_public_removed() {
 		var v1 = """
@@ -62,6 +69,10 @@ class TypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new A() {
+			I i;
+		};""")
 	@Test
 	void class_inner_protected_in_class_public_removed() {
 		var v1 = """
@@ -76,6 +87,7 @@ class TypeRemovedTest {
 		assertBC("A$I", TYPE_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("A.I i;")
 	@Test
 	void class_inner_public_in_class_public_removed() {
 		var v1 = """
@@ -90,6 +102,7 @@ class TypeRemovedTest {
 		assertBC("A$I", TYPE_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("// Cannot access A")
 	@Test
 	void class_inner_static_public_in_class_private_removed() {
 		var v1 = """
@@ -104,6 +117,10 @@ class TypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("""
+		new A() {
+			I i;
+		};""")
 	@Test
 	void class_inner_static_protected_in_class_public_removed() {
 		var v1 = """
@@ -118,6 +135,7 @@ class TypeRemovedTest {
 		assertBC("A$I", TYPE_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("A.I i;")
 	@Test
 	void class_inner_static_public_in_class_public_removed() {
 		var v1 = """
@@ -132,6 +150,7 @@ class TypeRemovedTest {
 		assertBC("A$I", TYPE_REMOVED, 2, buildDiff(v1, v2));
 	}
 
+	@Client("// Cannot access A")
 	@Test
 	void class_inner_public_static_in_class_private_removed() {
 		var v1 = """
@@ -146,6 +165,7 @@ class TypeRemovedTest {
 		assertNoBC(buildDiff(v1, v2));
 	}
 
+	@Client("@A int a;")
 	@Test
 	void annotation_interface_removed() {
 		var v1 = "public @interface A {}";

--- a/core/src/test/java/io/github/alien/roseau/utils/Client.java
+++ b/core/src/test/java/io/github/alien/roseau/utils/Client.java
@@ -1,0 +1,9 @@
+package io.github.alien.roseau.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+public @interface Client {
+	String value();
+}

--- a/scripts/generate_roseau_dataset.py
+++ b/scripts/generate_roseau_dataset.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+'''\nGenerate roseau-dataset from diff tests.\n\nThis script scans all JUnit test classes under:\n  core/src/test/java/io/github/alien/roseau/diff\n\nFor each @Test method, it extracts:\n  - test class name (e.g., FieldTypeChangedTest)\n  - test method name (e.g., boxing)\n  - code snippets assigned to local variables `v1` and `v2` inside the test method\n    (supports Java 21 text blocks: var v1 = \"\"\"...\"\"\"; var v2 = \"\"\"...\"\"\";)\n    If v1/v2 are not found or are empty strings, they are treated as empty.\n\nIt then writes the following structure under project root:\n  roseau-dataset/\n    client/src/{testClass}-{testName}/Main.java  (empty file)\n    v1/src/pkg/{testClass}-{testName}/{testName}.java  (package pkg; + code1)\n    v2/src/pkg/{testClass}-{testName}/{testName}.java  (package pkg; + code2)\n\nNotes:\n- The script is idempotent and overwrites existing files for the same cases.\n- Test and class names are sanitized to be filesystem-friendly.\n\nRun from repository root:\n  python3 scripts/generate_roseau_dataset.py\n'''
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Tuple, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIFF_TESTS_DIR = REPO_ROOT / "core" / "src" / "test" / "java" / "io" / "github" / "alien" / "roseau" / "diff"
+OUTPUT_ROOT = REPO_ROOT / "roseau-dataset"
+
+# Regex helpers
+# Matches a JUnit @Test method signature and captures the method name.
+TEST_METHOD_PATTERN = re.compile(
+    r"@Test\s*(?:\r?\n\s*)*(?:public\s+|protected\s+|private\s+|static\s+|final\s+|\s+)*void\s+(?P<name>[a-zA-Z_$][a-zA-Z0-9_$]*)\s*\(\s*\)\s*\{",
+    re.MULTILINE,
+)
+
+# Non-greedy extraction of a Java 21 text block assigned to var v1 / v2.
+# We intentionally allow optional types/var and whitespace.
+V_PATTERN = re.compile(
+    r"(?P<var>v1|v2)\s*=\s*(?P<value>\"\"\".*?\"\"\"|\".*?\"|null)\s*;",
+    re.DOTALL,
+)
+
+# Matches the entire body of a method starting at the opening '{' of the method
+# found by TEST_METHOD_PATTERN, accounting for nested braces inside.
+
+def _find_brace_matched_body(text: str, start_index: int) -> Tuple[int, int]:
+    """
+    Given text and index of the method opening '{', return (start, end) slice
+    covering the full method body including braces. Returns (-1, -1) if not found.
+    """
+    if start_index < 0 or start_index >= len(text) or text[start_index] != '{':
+        return -1, -1
+    depth = 0
+    i = start_index
+    while i < len(text):
+        ch = text[i]
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return start_index, i + 1
+        i += 1
+    return -1, -1
+
+
+def _unindent_java_text_block(s: str) -> str:
+    """Strip the surrounding triple quotes and return the raw content of a Java text block."""
+    if s.startswith('"""') and s.endswith('"""'):
+        inner = s[3:-3]
+        # Java text blocks preserve indentation; we return as-is.
+        # Leading newline after opening """ is customary; keep content as-is.
+        return inner
+    if s.startswith('"') and s.endswith('"'):
+        # Simple string literal: unescape minimal escapes (\n, \t, \r, \"), then return
+        body = s[1:-1]
+        body = body.encode('utf-8').decode('unicode_escape')
+        return body
+    if s == 'null':
+        return ''
+    return s
+
+
+def _sanitize(name: str) -> str:
+    # Replace spaces and risky path chars. Keep Java identifier chars and dash.
+    return re.sub(r"[^a-zA-Z0-9_$-]", "_", name)
+
+
+def _extract_v1_v2(method_body: str) -> Tuple[str, str]:
+    v1 = ''
+    v2 = ''
+    for m in V_PATTERN.finditer(method_body):
+        var = m.group('var')
+        raw = m.group('value').strip()
+        content = _unindent_java_text_block(raw)
+        if var == 'v1':
+            v1 = content
+        elif var == 'v2':
+            v2 = content
+    return v1, v2
+
+
+# Matches @Client annotation with a string or text block payload placed on the test method
+CLIENT_PATTERN = re.compile(r"@Client\s*\(\s*(\"\"\".*?\"\"\"|\".*?\"|null)\s*\)", re.DOTALL)
+
+def _iter_test_methods(content: str) -> Iterable[Tuple[str, str, str]]:
+    """
+    Yield (testName, methodBodyText, clientCode) for each @Test-annotated method.
+    clientCode is empty string when no @Client annotation is present.
+    """
+    for m in TEST_METHOD_PATTERN.finditer(content):
+        name = m.group('name')
+        # Find the position of the opening brace '{' matched by the pattern end
+        brace_pos = content.find('{', m.end() - 1)
+        if brace_pos == -1:
+            continue
+        start, end = _find_brace_matched_body(content, brace_pos)
+        if start == -1:
+            continue
+        # Heuristically search a window before the @Test for an adjacent @Client annotation
+        pre_start = max(0, m.start() - 500)
+        header_window = content[pre_start:m.start()]
+        client_code = ''
+        mc = CLIENT_PATTERN.search(header_window)
+        if mc:
+            raw = mc.group(1).strip()
+            client_code = _unindent_java_text_block(raw)
+        yield name, content[start:end], client_code
+
+
+def _write_case(test_class: str, test_name: str, code1: str, code2: str, client_code: str) -> None:
+    # Use underscore between class and test names for all outputs (client, v1, v2)
+    case_dir_us = f"{_sanitize(test_class)}_{_sanitize(test_name)}"
+
+    # client: match v1/v2 directory naming and include package declaration
+    client_dir = OUTPUT_ROOT / "client" / "src" / case_dir_us
+    client_dir.mkdir(parents=True, exist_ok=True)
+    package_line = f"package {case_dir_us};\n"
+    main_path = client_dir / "Main.java"
+    if client_code.strip():
+        main_src = (
+            package_line
+            + "\n"
+            + "public class Main {\n"
+            + "    public static void main(String[] args) {\n"
+            + "        " + client_code.strip() + "\n"
+            + "    }\n"
+            + "}\n"
+        )
+        main_path.write_text(main_src, encoding="utf-8")
+    else:
+        # Keep minimal file with just package declaration if no @Client provided
+        main_path.write_text(package_line, encoding="utf-8")
+
+    # v1 (drop 'pkg' directory level)
+    v1_dir = OUTPUT_ROOT / "v1" / "src" / case_dir_us
+    v1_dir.mkdir(parents=True, exist_ok=True)
+    _write_java_files_for_code(v1_dir, package_line, test_name, code1)
+
+    # v2 (drop 'pkg' directory level)
+    v2_dir = OUTPUT_ROOT / "v2" / "src" / case_dir_us
+    v2_dir.mkdir(parents=True, exist_ok=True)
+    _write_java_files_for_code(v2_dir, package_line, test_name, code2)
+
+
+# -------- Helpers for extracting top-level type declarations and writing files --------
+TYPE_DECL_PATTERN = re.compile(r"(class|interface|enum|record|@interface)\s+([A-Za-z_][A-Za-z0-9_]*)", re.MULTILINE)
+
+
+def _compute_brace_depths(text: str) -> list[int]:
+    depths: List[int] = [0] * len(text)
+    depth = 0
+    i = 0
+    in_sl_comment = False
+    in_ml_comment = False
+    in_str = False
+    str_delim = ''
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ''
+        if in_sl_comment:
+            if ch == '\n':
+                in_sl_comment = False
+        elif in_ml_comment:
+            if ch == '*' and nxt == '/':
+                in_ml_comment = False
+                i += 1
+        elif in_str:
+            if ch == '\\':
+                i += 1  # skip escaped
+            elif ch == str_delim:
+                in_str = False
+        else:
+            # not in string/comment
+            if ch == '/' and nxt == '/':
+                in_sl_comment = True
+                i += 1
+            elif ch == '/' and nxt == '*':
+                in_ml_comment = True
+                i += 1
+            elif ch in ('"', "'"):
+                in_str = True
+                str_delim = ch
+            elif ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth = max(0, depth - 1)
+        depths[i] = depth
+        i += 1
+    return depths
+
+
+def _find_matching_brace(text: str, open_index: int) -> Optional[int]:
+    depth = 0
+    i = open_index
+    in_sl_comment = False
+    in_ml_comment = False
+    in_str = False
+    str_delim = ''
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ''
+        if in_sl_comment:
+            if ch == '\n':
+                in_sl_comment = False
+        elif in_ml_comment:
+            if ch == '*' and nxt == '/':
+                in_ml_comment = False
+                i += 1
+        elif in_str:
+            if ch == '\\':
+                i += 1
+            elif ch == str_delim:
+                in_str = False
+        else:
+            if ch == '/' and nxt == '/':
+                in_sl_comment = True
+                i += 1
+            elif ch == '/' and nxt == '*':
+                in_ml_comment = True
+                i += 1
+            elif ch in ('"', "'"):
+                in_str = True
+                str_delim = ch
+            elif ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return i
+        i += 1
+    return None
+
+
+def _extract_type_declarations(code: str) -> List[Tuple[str, str]]:
+    results: List[Tuple[str, str]] = []
+    if not code:
+        return results
+    depths = _compute_brace_depths(code)
+    for m in re.finditer(r"(?ms)(^[\t ]*(?:@[A-Za-z0-9_$.]+(?:\([^)]*\))?[\t ]*)*(?:public|protected|private|abstract|final|sealed|non-sealed|nonsealed|static|strictfp|\s)*)\s*(class|interface|enum|record|@interface)\s+([A-Za-z_][A-Za-z0-9_]*)[^\{;]*\{", code):
+        annos_and_ws = m.group(1)
+        kind = m.group(2)
+        name = m.group(3)
+        brace_pos = code.find('{', m.end() - 1)
+        if brace_pos == -1:
+            continue
+        # ensure top-level
+        if brace_pos < len(depths) and depths[brace_pos] != 1:
+            # We want the declaration's opening brace to bring depth to 1 (i.e., top-level)
+            continue
+        end_brace = _find_matching_brace(code, brace_pos)
+        if end_brace is None:
+            continue
+        # Expand start to include annotations directly above, captured in group(1)
+        start = m.start(2) - len(annos_and_ws)
+        if start < 0:
+            start = m.start(2)
+        decl_text = code[start:end_brace + 1]
+        results.append((name, decl_text))
+    return results
+
+
+def _write_java_files_for_code(out_dir: Path, package_line: str, fallback_name: str, code: str) -> None:
+    if not code:
+        # Respect prior behavior: create empty file if code is empty
+        (out_dir / f"{fallback_name}.java").write_text("", encoding="utf-8")
+        return
+    decls = _extract_type_declarations(code)
+    if decls:
+        for type_name, decl_text in decls:
+            (out_dir / f"{type_name}.java").write_text(package_line + decl_text, encoding="utf-8")
+        # Remove previously created fallback file if it exists
+        fb = out_dir / f"{fallback_name}.java"
+        if fb.exists():
+            try:
+                fb.unlink()
+            except Exception:
+                pass
+    else:
+        # Fallback: no type declarations found; still write single file to keep data
+        (out_dir / f"{fallback_name}.java").write_text(package_line + code, encoding="utf-8")
+
+
+# ----------------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    if not DIFF_TESTS_DIR.exists():
+        print(f"[ERROR] Tests directory not found: {DIFF_TESTS_DIR}", file=sys.stderr)
+        return 1
+
+    OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+
+    total_classes = 0
+    total_cases = 0
+
+    for test_file in sorted(DIFF_TESTS_DIR.glob("*.java")):
+        content = test_file.read_text(encoding="utf-8")
+        test_class = test_file.stem  # e.g., FieldTypeChangedTest
+        class_cases = 0
+        for test_name, body, client_code in _iter_test_methods(content):
+            v1, v2 = _extract_v1_v2(body)
+            _write_case(test_class, test_name, v1, v2, client_code)
+            total_cases += 1
+            class_cases += 1
+        if class_cases > 0:
+            total_classes += 1
+            print(f"Processed {class_cases:3d} test(s) from {test_class}")
+
+    print(f"\nDone. Classes with tests: {total_classes}, total test cases: {total_cases}")
+    print(f"Output written under: {OUTPUT_ROOT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/generate_roseau_dataset.py
+++ b/scripts/generate_roseau_dataset.py
@@ -106,9 +106,10 @@ def _iter_test_methods(content: str) -> Iterable[Tuple[str, str, str]]:
         pre_start = max(0, m.start() - 500)
         header_window = content[pre_start:m.start()]
         client_code = ''
-        mc = CLIENT_PATTERN.search(header_window)
-        if mc:
-            raw = mc.group(1).strip()
+        # Find the closest (last) @Client before this @Test to avoid picking one from a previous method
+        mc_iter = list(CLIENT_PATTERN.finditer(header_window))
+        if mc_iter:
+            raw = mc_iter[-1].group(1).strip()
             client_code = _unindent_java_text_block(raw)
         yield name, content[start:end], client_code
 


### PR DESCRIPTION
Roseau's test suites defines many evolution cases that could be useful for:
  - Using the compiler as groundtruth to check whether a particular case is indeed breaking/compatible

A typical BC test case now looks like this:

```
@Client("new A().m();")
@Test
void public_to_protected() {
  var v1 = """
    public class A {
      public void m() {}
    }""";
  var v2 = """
    public class A {
      protected void m() {}
    }""";

  assertBC("A.m", BreakingChangeKind.METHOD_NOW_PROTECTED, 2, buildDiff(v1, v2));
}
```