### PR TITLE
Ensure Roseau successfully runs on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,35 @@ on:
     types: [ released, published ]
 
 jobs:
+  verify:
+    name: Verify on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Verify build
+        run: mvn --batch-mode verify
+        env:
+          # Ensure UTF-8 (Windows might not)
+          MAVEN_OPTS: -Dfile.encoding=UTF-8
+
   publish:
+    name: Publish new version on Sonatype Central
     runs-on: ubuntu-latest
+    needs: verify
+    if: ${{ needs.verify.result == 'success' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/core/src/main/java/io/github/alien/roseau/api/model/SourceLocation.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/SourceLocation.java
@@ -1,7 +1,5 @@
 package io.github.alien.roseau.api.model;
 
-import com.google.common.base.Preconditions;
-
 import java.nio.file.Path;
 
 /**
@@ -16,18 +14,17 @@ public record SourceLocation(
 	int line
 ) {
 	public SourceLocation(Path file, int line) {
-		Preconditions.checkNotNull(file);
-		this.file = file.toAbsolutePath();
+		this.file = file != null ? file.toAbsolutePath() : null;
 		this.line = line;
 	}
 
 	/**
 	 * An unknown location for symbols that exist but cannot be located in source code (e.g. default constructors)
 	 */
-	public static final SourceLocation NO_LOCATION = new SourceLocation(Path.of("<unknown>"), -1);
+	public static final SourceLocation NO_LOCATION = new SourceLocation(null, -1);
 
 	@Override
 	public String toString() {
-		return file + ":" + line;
+		return (file != null ? file : "<unknown>") + ":" + line;
 	}
 }

--- a/core/src/main/java/io/github/alien/roseau/extractors/asm/AsmClassVisitor.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/asm/AsmClassVisitor.java
@@ -46,7 +46,7 @@ import java.util.stream.IntStream;
 final class AsmClassVisitor extends ClassVisitor {
 	private final TypeReferenceFactory typeRefFactory;
 	private String className;
-	private Path sourceFile = Path.of("<unknown>");
+	private Path sourceFile;
 	private int classAccess;
 	private TypeDecl typeDecl;
 	private TypeReference<TypeDecl> enclosingType;

--- a/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
@@ -504,7 +504,7 @@ public class SpoonAPIFactory {
 		} else if (fallback != null && fallback.getPosition() != null) {
 			SourcePosition fallbackPosition = fallback.getPosition();
 			if (fallbackPosition.isValidPosition() && fallbackPosition.getFile() != null) {
-				return new SourceLocation(fallback.getPosition().getFile().toPath(), -1);
+				return new SourceLocation(fallbackPosition.getFile().toPath(), -1);
 			}
 		}
 

--- a/core/src/test/java/io/github/alien/roseau/extractors/MavenClasspathBuilderTest.java
+++ b/core/src/test/java/io/github/alien/roseau/extractors/MavenClasspathBuilderTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MavenClasspathBuilderTest {
 	@TempDir
@@ -70,8 +69,8 @@ class MavenClasspathBuilderTest {
 	@Test
 	void unknown_file() {
 		var builder = new MavenClasspathBuilder();
-		var path = Path.of("unknown");
-		assertThrows(IllegalArgumentException.class, () -> builder.buildClasspath(path));
+		var cp = builder.buildClasspath(Path.of("unknown"));
+		assertThat(cp).isEmpty();
 	}
 
 	@Test
@@ -81,9 +80,9 @@ class MavenClasspathBuilderTest {
 		assertThat(cp)
 			.hasSizeGreaterThanOrEqualTo(2)
 			.anySatisfy(p -> assertThat(p).asString()
-				.endsWith("org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"))
+				.endsWith("commons-lang3-3.12.0.jar"))
 			.anySatisfy(p -> assertThat(p).asString()
-				.endsWith("com/google/guava/guava/31.1-jre/guava-31.1-jre.jar"));
+				.endsWith("guava-31.1-jre.jar"));
 	}
 
 	@Test


### PR DESCRIPTION
- [X] Get rid of the buggy `<unknown>` sentinel physical location
- [X] Make the `MavenClasspathBuilder` retrieve some `mvn` executable locally
- [X] Make sure the tests pass on Windows
- [X] `release.yml`: ensure the build passes on `windows-latest` before releasing