### PR TITLE
Support external YAML configuration file

### DIFF
--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -277,7 +277,7 @@ public final class RoseauCLI implements Callable<Integer> {
 		);
 		RoseauOptions.Library v1Cli = new RoseauOptions.Library(
 			v1, v1ExtractorType, new RoseauOptions.Classpath(v1Pom, buildClasspathFromString(v1Classpath)),
-			noExclusions, null
+			noExclusions, apiJson
 		);
 		RoseauOptions.Library v2Cli = new RoseauOptions.Library(
 			v2, v2ExtractorType, new RoseauOptions.Classpath(v2Pom, buildClasspathFromString(v2Classpath)),

--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -161,7 +161,9 @@ public final class RoseauCLI implements Callable<Integer> {
 
 	private void writeReport(RoseauReport report, BreakingChangesFormatterFactory format, Path path) {
 		try {
-			Files.createDirectories(path.getParent());
+			if (path.getParent() != null) {
+				Files.createDirectories(path.getParent());
+			}
 			BreakingChangesFormatter fmt = BreakingChangesFormatterFactory.newBreakingChangesFormatter(format);
 			Files.writeString(path, fmt.format(report), StandardCharsets.UTF_8);
 			printVerbose("Report has been written to %s".formatted(path));
@@ -172,7 +174,9 @@ public final class RoseauCLI implements Callable<Integer> {
 
 	private void writeApiReport(API api, Path apiPath) {
 		try {
-			Files.createDirectories(apiPath.getParent());
+			if (apiPath.getParent() != null) {
+				Files.createDirectories(apiPath.getParent());
+			}
 			api.getLibraryTypes().writeJson(apiPath);
 			printVerbose("API has been written to %s".formatted(apiPath));
 		} catch (IOException e) {
@@ -189,12 +193,13 @@ public final class RoseauCLI implements Callable<Integer> {
 				member.getContainingType().getQualifiedName().equals(bc.impactedType().getQualifiedName());
 
 		if (plain) {
-			return String.format("%s %s%s%n\t%s:%s", bc.kind(),
+			return "%s %s%s%n\t%s:%s".formatted(
+				bc.kind(),
 				bc.impactedSymbol().getQualifiedName(),
 				symbolInType ? "" : " in " + bc.impactedType().getQualifiedName(),
 				location.file(), location.line());
 		} else {
-			return String.format("%s %s%s%n\t%s:%s",
+			return "%s %s%s%n\t%s:%s".formatted(
 				RED_TEXT + BOLD + bc.kind() + RESET,
 				UNDERLINE + bc.impactedSymbol().getQualifiedName() + RESET,
 				symbolInType ? "" : " in " + bc.impactedType().getQualifiedName(),
@@ -259,6 +264,11 @@ public final class RoseauCLI implements Callable<Integer> {
 		Path v2PomPath = options.v2().classpath().pom();
 		if (v2PomPath != null && !Files.isRegularFile(v2PomPath)) {
 			throw new RoseauException("Cannot find pom: %s".formatted(v2PomPath));
+		}
+
+		Path pomPath = options.common().classpath().pom();
+		if (pomPath != null && !Files.isRegularFile(pomPath)) {
+			throw new RoseauException("Cannot find pom: %s".formatted(pomPath));
 		}
 
 		Path ignoredPath = options.ignore();

--- a/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
+++ b/cli/src/main/java/io/github/alien/roseau/cli/RoseauCLI.java
@@ -4,6 +4,7 @@ import com.google.common.base.Stopwatch;
 import io.github.alien.roseau.Library;
 import io.github.alien.roseau.Roseau;
 import io.github.alien.roseau.RoseauException;
+import io.github.alien.roseau.RoseauOptions;
 import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.api.model.SourceLocation;
 import io.github.alien.roseau.api.model.TypeDecl;
@@ -14,10 +15,7 @@ import io.github.alien.roseau.diff.changes.BreakingChangeKind;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatter;
 import io.github.alien.roseau.diff.formatter.BreakingChangesFormatterFactory;
 import io.github.alien.roseau.diff.formatter.CsvFormatter;
-import io.github.alien.roseau.diff.formatter.HtmlFormatter;
-import io.github.alien.roseau.diff.formatter.MdFormatter;
 import io.github.alien.roseau.extractors.ExtractorType;
-import io.github.alien.roseau.extractors.MavenClasspathBuilder;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -30,9 +28,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -78,30 +77,46 @@ public final class RoseauCLI implements Callable<Integer> {
 	@Option(names = "--report", paramLabel = "<path>",
 		description = "Where to write the breaking changes report in --diff mode")
 	private Path reportPath;
-	@Option(names = "--format", defaultValue = "CSV",
+	@Option(names = "--format",
 		description = "Format of the report: ${COMPLETION-CANDIDATES}")
 	private BreakingChangesFormatterFactory format;
-	@Option(names = "--pom", paramLabel = "<path>",
-		description = "A pom.xml file to build a classpath from")
-	private Path pom;
 	@Option(names = "--classpath", paramLabel = "<path>[,<path>...]",
-		description = "A colon-separated list of JARs to include in the classpath (Windows: semi-colon)")
-	private String userClasspath;
+		description = "A colon-separated list of JARs to include in the classpath (Windows: semi-colon), " +
+			"shared by --v1 and --v2")
+	private String classpath;
+	@Option(names = "--pom", paramLabel = "<path>",
+		description = "A pom.xml file to build a classpath from, shared by --v1 and --v2")
+	private Path pom;
+	@Option(names = "--v1-classpath", paramLabel = "<path>[,<path>...]",
+		description = "A --classpath for --v1")
+	private String v1Classpath;
+	@Option(names = "--v2-classpath", paramLabel = "<path>[,<path>...]",
+		description = "A --classpath for --v2")
+	private String v2Classpath;
+	@Option(names = "--v1-pom", paramLabel = "<path>",
+		description = "A --pom for --v1")
+	private Path v1Pom;
+	@Option(names = "--v2-pom", paramLabel = "<path>",
+		description = "A --pom for --v2")
+	private Path v2Pom;
 	@Option(names = "--ignored", paramLabel = "<path>",
 		description = "Do not report the breaking changes listed in the given CSV file; " +
 			"this CSV file shares the same structure as the one produced by --format CSV")
 	private Path ignoredCsv;
+	@Option(names = "--config", paramLabel = "<path>",
+		description = "A roseau.yaml config file; overridden by CLI options")
+	private Path config;
 	@Option(names = "--fail-on-bc",
 		description = "Return 1 if breaking changes are detected")
 	private boolean failMode;
 	@Option(names = "--plain",
 		description = "Disable ANSI colors, output plain text")
 	private boolean plain;
-	@Option(names = "--verbose",
-		description = "Print debug information")
+	@Option(names = {"-v", "--verbose"},
+		description = "Increase verbosity (-v, -vv).")
+	private boolean[] verbosity;
 	private boolean verbose;
-	@Option(names = "--github-action", hidden = true)
-	private boolean githubActionMode;
+	private boolean debug;
 
 	private static final String RED_TEXT = "\u001B[31m";
 	private static final String BOLD = "\u001B[1m";
@@ -131,66 +146,33 @@ public final class RoseauCLI implements Callable<Integer> {
 		return report;
 	}
 
-	private Set<Path> buildClasspath() {
-		Set<Path> classpath = userClasspath != null
-			? Arrays.stream(userClasspath.split(File.pathSeparator))
+	private static Set<Path> buildClasspathFromString(String cp) {
+		return cp != null
+			? Arrays.stream(cp.split(File.pathSeparator))
+			.filter(p -> p.endsWith(".jar"))
 			.map(Path::of)
-			.collect(Collectors.toCollection(HashSet::new))
-			: new HashSet<>();
-
-		if (pom != null && Files.isRegularFile(pom)) {
-			Stopwatch sw = Stopwatch.createStarted();
-			MavenClasspathBuilder classpathBuilder = new MavenClasspathBuilder();
-			classpath.addAll(classpathBuilder.buildClasspath(pom));
-			printVerbose("Extracting classpath from %s took %dms".formatted(
-				pom, sw.elapsed().toMillis()));
-		}
-
-		if (classpath.isEmpty()) {
-			print("Warning: no classpath provided, results may be inaccurate");
-		} else {
-			printVerbose("Classpath: %s".formatted(classpath));
-		}
-
-		return classpath;
+			.collect(Collectors.toSet())
+			: Set.of();
 	}
 
-	private void writeReport(API api, RoseauReport report) {
-		// FIXME once we can write multiple reports at once
-		if (githubActionMode) {
-			writeGithubActionReport(api, report);
-			return;
-		}
-
-		if (reportPath == null) {
-			return;
-		}
-
+	private void writeReport(RoseauReport report, BreakingChangesFormatterFactory format, Path path) {
 		try {
+			Files.createDirectories(path.getParent());
 			BreakingChangesFormatter fmt = BreakingChangesFormatterFactory.newBreakingChangesFormatter(format);
-			Files.writeString(reportPath, fmt.format(api, report), StandardCharsets.UTF_8);
-			print("Report has been written to %s".formatted(reportPath));
+			Files.writeString(path, fmt.format(report), StandardCharsets.UTF_8);
+			print("Report has been written to %s".formatted(path));
 		} catch (IOException e) {
-			throw new RoseauException("Error writing report to %s".formatted(reportPath), e);
+			throw new RoseauException("Error writing report to %s".formatted(path), e);
 		}
 	}
 
-	private void writeApiReport(API api) {
+	private void writeApiReport(API api, Path apiPath) {
 		try {
-			api.getLibraryTypes().writeJson(apiJson);
-			print("API has been written to %s".formatted(apiJson));
+			Files.createDirectories(apiPath.getParent());
+			api.getLibraryTypes().writeJson(apiPath);
+			print("API has been written to %s".formatted(apiPath));
 		} catch (IOException e) {
-			throw new RoseauException("Error writing API to %s".formatted(apiJson), e);
-		}
-	}
-
-	private void writeGithubActionReport(API api, RoseauReport report) {
-		try {
-			Files.writeString(Path.of("report.csv"), new CsvFormatter().format(api, report));
-			Files.writeString(Path.of("report.html"), new HtmlFormatter().format(api, report));
-			Files.writeString(Path.of("report.md"), new MdFormatter().format(api, report));
-		} catch (IOException e) {
-			throw new RoseauException("Error writing GHA reports", e);
+			throw new RoseauException("Error writing API to %s".formatted(apiPath), e);
 		}
 	}
 
@@ -216,21 +198,17 @@ public final class RoseauCLI implements Callable<Integer> {
 		}
 	}
 
-	private List<BreakingChange> filterIgnoredBCs(RoseauReport report) {
-		if (ignoredCsv == null) {
-			return report.breakingChanges();
-		}
-
+	private List<BreakingChange> filterIgnoredBCs(RoseauReport report, Path ignoredPath) {
 		try {
 			record Ignored(String type, String symbol, BreakingChangeKind kind) {}
-			List<String> lines = Files.readAllLines(ignoredCsv);
+			List<String> lines = Files.readAllLines(ignoredPath);
 			List<Ignored> ignored = lines.stream()
 				.filter(line -> !line.equals(CsvFormatter.HEADER))
 				.map(line -> {
 					String[] fields = line.split(";");
 					if (fields.length < 3 ||
 						Arrays.stream(BreakingChangeKind.values()).map(Enum::name).noneMatch(name -> name.equals(fields[2]))) {
-						printErr("Malformed line %s ignored in %s".formatted(line, ignoredCsv));
+						printErr("Malformed line %s ignored in %s".formatted(line, ignoredPath));
 						return null;
 					} else {
 						return new Ignored(fields[0], fields[1], BreakingChangeKind.valueOf(fields[2]));
@@ -246,78 +224,163 @@ public final class RoseauCLI implements Callable<Integer> {
 						bc.kind() == ign.kind()))
 				.toList();
 		} catch (IOException e) {
-			throw new RoseauException("Couldn't read CSV file %s".formatted(ignoredCsv), e);
+			throw new RoseauException("Couldn't read CSV file %s".formatted(ignoredPath), e);
 		}
 	}
 
-	private void checkArguments() {
-		if (v1 == null || !Files.exists(v1)) {
-			throw new RoseauException("Cannot find v1: %s".formatted(v1));
+	private void checkOptions(RoseauOptions options) {
+		Path v1Path = options.diff().v1().location();
+		if (v1Path == null || !Files.exists(v1Path)) {
+			throw new RoseauException("Cannot find v1: %s".formatted(v1Path));
 		}
 
-		if (mode.api && apiJson == null) {
-			throw new RoseauException("--api-json required in --api mode");
+		if (mode.api && options.diff().v1().apiReport() == null) {
+			throw new RoseauException("Path to a JSON file required in --api mode");
 		}
 
-		if (mode.diff && (v2 == null || !Files.exists(v2))) {
-			throw new RoseauException("Cannot find v2: %s".formatted(v2));
+		Path v2Path = options.diff().v2().location();
+		if (mode.diff && (v2Path == null || !Files.exists(v2Path))) {
+			throw new RoseauException("Cannot find v2: %s".formatted(v2Path));
 		}
 
-		if (pom != null && !Files.isRegularFile(pom)) {
-			throw new RoseauException("Cannot find pom: %s".formatted(pom));
+		if (reportPath != null && format == null) {
+			throw new RoseauException("--format required with --report");
 		}
 
-		if (ignoredCsv != null && !Files.isRegularFile(ignoredCsv)) {
-			throw new RoseauException("Cannot find ignored CSV: %s".formatted(ignoredCsv));
+		Path v1PomPath = options.diff().v1().classpath().pom();
+		if (v1PomPath != null && !Files.isRegularFile(v1PomPath)) {
+			throw new RoseauException("Cannot find pom: %s".formatted(v1PomPath));
 		}
+
+		Path v2PomPath = options.diff().v2().classpath().pom();
+		if (v2PomPath != null && !Files.isRegularFile(v2PomPath)) {
+			throw new RoseauException("Cannot find pom: %s".formatted(v2PomPath));
+		}
+
+		Path ignoredPath = options.diff().ignore();
+		if (ignoredPath != null && !Files.isRegularFile(ignoredPath)) {
+			throw new RoseauException("Cannot find ignored CSV: %s".formatted(ignoredPath));
+		}
+	}
+
+	private RoseauOptions makeCliOptions() {
+		RoseauOptions.Library v1Cli = new RoseauOptions.Library(
+			v1, extractorType,
+			new RoseauOptions.Classpath(
+				Optional.ofNullable(v1Pom).orElse(pom),
+				buildClasspathFromString(Optional.ofNullable(v1Classpath).orElse(classpath))
+			),
+			new RoseauOptions.Exclude(List.of(), List.of()), // FIXME
+			apiJson
+		);
+		RoseauOptions.Library v2Cli = new RoseauOptions.Library(
+			v2, extractorType,
+			new RoseauOptions.Classpath(
+				Optional.ofNullable(v2Pom).orElse(pom),
+				buildClasspathFromString(Optional.ofNullable(v2Classpath).orElse(classpath))
+			),
+			new RoseauOptions.Exclude(List.of(), List.of()), // FIXME
+			apiJson
+		);
+		List<RoseauOptions.Report> reportsCli = (reportPath != null && format != null)
+			? List.of(new RoseauOptions.Report(reportPath, format))
+			: List.of();
+		return new RoseauOptions(new RoseauOptions.Diff(v1Cli, v2Cli, ignoredCsv, reportsCli));
+	}
+
+	private Library makeLibrary(RoseauOptions.Library library) {
+		return Library.builder()
+			.location(library.location())
+			.classpath(library.classpath().jars())
+			.pom(library.classpath().pom())
+			.extractorType(library.extractor())
+			.exclusions(library.excludes())
+			.build();
+	}
+
+	private void doApi(Library library, RoseauOptions.Library libraryOptions) {
+		if (library.getClasspath().isEmpty()) {
+			printErr("Warning: no classpath provided for %s, results may be inaccurate".formatted(library.getLocation()));
+		}
+		API api = buildAPI(library);
+		if (libraryOptions.apiReport() != null) {
+			writeApiReport(api, libraryOptions.apiReport());
+		}
+	}
+
+	private boolean doDiff(Library v1, Library v2, RoseauOptions.Diff diffOptions) {
+		if (v1.getClasspath().isEmpty()) {
+			printErr("Warning: no classpath provided for %s, results may be inaccurate".formatted(v1.getLocation()));
+		}
+		if (v2.getClasspath().isEmpty()) {
+			printErr("Warning: no classpath provided for %s, results may be inaccurate".formatted(v2.getLocation()));
+		}
+		RoseauReport report = diff(v1, v2);
+		Path ignoreFile = diffOptions.ignore();
+		List<BreakingChange> bcs = ignoreFile != null && Files.isRegularFile(ignoreFile)
+			? filterIgnoredBCs(report, ignoreFile)
+			: report.breakingChanges();
+
+		if (bcs.isEmpty()) {
+			print("No breaking changes found.");
+		} else {
+			print(
+				bcs.stream()
+					.map(this::format)
+					.collect(Collectors.joining(System.lineSeparator()))
+			);
+		}
+
+		if (diffOptions.v1().apiReport() != null) {
+			writeApiReport(report.v1(), diffOptions.v1().apiReport());
+		}
+		if (diffOptions.v2().apiReport() != null) {
+			writeApiReport(report.v2(), diffOptions.v2().apiReport());
+		}
+		diffOptions.reports().forEach(reportOption ->
+			writeReport(report, reportOption.format(), reportOption.file())
+		);
+
+		return !bcs.isEmpty();
 	}
 
 	@Override
 	public Integer call() {
 		try {
-			if (verbose) {
-				Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.DEBUG);
+			if (verbosity != null) {
+				this.verbose = verbosity.length > 0;
+				this.debug = verbosity.length > 1;
 			}
 
-			checkArguments();
-			List<Path> classpath = buildClasspath().stream().toList();
-			Library.Builder builder1 = Library.builder()
-				.location(v1)
-				.classpath(classpath);
-			if (extractorType != null) {
-				builder1.extractorType(extractorType);
+			if (debug) {
+				Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.DEBUG);
+			} else if (verbose) {
+				Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.INFO);
 			}
-			Library libraryV1 = builder1.build();
+
+			RoseauOptions cliOptions = makeCliOptions();
+			RoseauOptions fileOptions = config != null && Files.isRegularFile(config)
+				? RoseauOptions.load(config)
+				: RoseauOptions.newDefault();
+			RoseauOptions options = fileOptions.mergeWith(cliOptions);
+			checkOptions(options);
+			printDebug("Options are " + options);
 
 			if (mode.api) {
-				API api = buildAPI(libraryV1);
-				writeApiReport(api);
+				Library libraryV1 = makeLibrary(options.diff().v1());
+				printDebug("v1 = " + libraryV1);
+				doApi(libraryV1, options.diff().v1());
 			}
 
 			if (mode.diff) {
-				Library.Builder builder2 = Library.builder()
-					.location(v2)
-					.classpath(classpath);
-				if (extractorType != null) {
-					builder2.extractorType(extractorType);
-				}
-				Library libraryV2 = builder2.build();
-				RoseauReport report = diff(libraryV1, libraryV2);
-				List<BreakingChange> bcs = filterIgnoredBCs(report);
+				Library libraryV1 = makeLibrary(options.diff().v1());
+				Library libraryV2 = makeLibrary(options.diff().v2());
+				printDebug("v1 = " + libraryV1);
+				printDebug("v2 = " + libraryV2);
+				boolean breaking = doDiff(libraryV1, libraryV2, options.diff());
 
-				if (bcs.isEmpty()) {
-					print("No breaking changes found.");
-				} else {
-					print(
-						bcs.stream()
-							.map(this::format)
-							.collect(Collectors.joining(System.lineSeparator()))
-					);
-					writeReport(report.v1(), report);
-
-					if (failMode) {
-						return 1;
-					}
+				if (breaking && failMode) {
+					return 1;
 				}
 			}
 
@@ -338,6 +401,12 @@ public final class RoseauCLI implements Callable<Integer> {
 
 	private void printVerbose(String message) {
 		if (verbose) {
+			print(message);
+		}
+	}
+
+	private void printDebug(String message) {
+		if (debug) {
 			print(message);
 		}
 	}

--- a/cli/src/test/java/io/github/alien/roseau/cli/RoseauCLITest.java
+++ b/cli/src/test/java/io/github/alien/roseau/cli/RoseauCLITest.java
@@ -154,7 +154,6 @@ class RoseauCLITest {
 			"--api",
 			"--api-json=" + jsonFile);
 
-		assertThat(out.toString()).contains("API has been written to " + jsonFile);
 		assertThat(jsonFile).isNotEmptyFile();
 		assertThat(exitCode).isZero();
 	}
@@ -234,7 +233,7 @@ class RoseauCLITest {
 			"--pom=src/test/resources/none.xml",
 			"--api-json=" + api);
 
-		assertThat(err.toString()).contains("Cannot find pom:");
+		assertThat(err.toString()).contains("Invalid path to POM file:");
 		assertThat(exitCode).isEqualTo(2);
 	}
 
@@ -302,7 +301,6 @@ class RoseauCLITest {
 			"--report=" + reportFile,
 			"--format=CSV");
 
-		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
 		assertThat(exitCode).isZero();
 	}
@@ -316,7 +314,6 @@ class RoseauCLITest {
 			"--format=HTML",
 			"--report=" + reportFile);
 
-		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
 		assertThat(exitCode).isZero();
 	}
@@ -330,7 +327,6 @@ class RoseauCLITest {
 			"--format=JSON",
 			"--report=" + reportFile);
 
-		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
 		assertThat(exitCode).isZero();
 	}
@@ -344,7 +340,6 @@ class RoseauCLITest {
 			"--format=MD",
 			"--report=" + reportFile);
 
-		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
 		assertThat(exitCode).isZero();
 	}

--- a/cli/src/test/java/io/github/alien/roseau/cli/RoseauCLITest.java
+++ b/cli/src/test/java/io/github/alien/roseau/cli/RoseauCLITest.java
@@ -233,7 +233,7 @@ class RoseauCLITest {
 			"--pom=src/test/resources/none.xml",
 			"--api-json=" + api);
 
-		assertThat(err.toString()).contains("Invalid path to POM file:");
+		assertThat(err.toString()).contains("Cannot find pom:");
 		assertThat(exitCode).isEqualTo(2);
 	}
 

--- a/cli/src/test/java/io/github/alien/roseau/cli/RoseauCLITest.java
+++ b/cli/src/test/java/io/github/alien/roseau/cli/RoseauCLITest.java
@@ -5,16 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,8 +32,8 @@ class RoseauCLITest {
 	void no_mode() {
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Missing required argument (specify one of these): (--api | --diff)");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	// --- Diffs --- //
@@ -48,8 +44,8 @@ class RoseauCLITest {
 			"--diff",
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("METHOD_REMOVED pkg.T.m");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -59,8 +55,8 @@ class RoseauCLITest {
 			"--diff",
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("METHOD_REMOVED pkg.T.m");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -70,8 +66,8 @@ class RoseauCLITest {
 			"--diff",
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("METHOD_REMOVED pkg.T.m");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -81,8 +77,8 @@ class RoseauCLITest {
 			"--diff",
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("METHOD_REMOVED pkg.T.m");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -91,8 +87,8 @@ class RoseauCLITest {
 			"--v2=src/test/resources/test-project-v1/test-project-v1.jar",
 			"--diff");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("No breaking changes found.");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -101,16 +97,16 @@ class RoseauCLITest {
 			"--v2=src/test/resources/test-project-v2/test-project-v1.jar",
 			"--diff");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Cannot find v1:");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
 	void missing_v1() {
 		var exitCode = cmd.execute("--api");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Cannot find v1:");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -118,8 +114,8 @@ class RoseauCLITest {
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
 			"--diff");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Cannot find v2:");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -144,12 +140,11 @@ class RoseauCLITest {
 	// --- APIs --- //
 	@Test
 	void write_api_no_file() {
-		var defaultFile = Path.of("api.json");
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
 			"--api");
 
+		assertThat(err.toString()).contains("Path to a JSON file required in --api mode");
 		assertThat(exitCode).isEqualTo(2);
-		assertThat(err.toString()).contains("--api-json required in --api mode");
 	}
 
 	@Test
@@ -159,9 +154,9 @@ class RoseauCLITest {
 			"--api",
 			"--api-json=" + jsonFile);
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("API has been written to " + jsonFile);
 		assertThat(jsonFile).isNotEmptyFile();
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -173,11 +168,11 @@ class RoseauCLITest {
 			"--api-json=" + jsonFile,
 			"--verbose");
 
-		assertThat(exitCode).isZero();
 		assertThat(jsonFile).isNotEmptyFile();
 		assertThat(out.toString())
 			.contains("Extracting API from", "using SPOON")
 			.contains("API has been written to " + jsonFile);
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -191,8 +186,8 @@ class RoseauCLITest {
 			"--api-json=" + apiFile);
 
 		// Should succeed despite I/O error - CLI continues execution
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Error writing API to " + apiFile);
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	// --- Options --- //
@@ -202,43 +197,20 @@ class RoseauCLITest {
 			"--v2=src/test/resources/test-project-v2/src",
 			"--diff");
 
+		assertThat(err.toString()).contains("Warning: no classpath provided", "results may be inaccurate");
 		assertThat(exitCode).isZero();
-		assertThat(out.toString()).contains("Warning: no classpath provided, results may be inaccurate");
-	}
-
-	@Test
-	void custom_classpath_deduplicated() {
-		var cp = String.join(File.pathSeparator,
-			"src/test/resources/test-project-v1/test-project-v1.jar",
-			"src/test/resources/test-project-v2/test-project-v2.jar",
-			"src/test/resources/test-project-v1/test-project-v1.jar"
-		);
-		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
-			"--v2=src/test/resources/test-project-v2/src",
-			"--diff",
-			"--classpath=" + cp,
-			"--verbose");
-
-		assertThat(exitCode).isZero();
-		assertThat(out.toString())
-			.containsOnlyOnce("Classpath: [")
-			.containsOnlyOnce("test-project-v1.jar")
-			.containsOnlyOnce("test-project-v2.jar");
 	}
 
 	@Test
 	void valid_pom(@TempDir Path tempDir) {
 		var api = tempDir.resolve("api.json");
-		var pom = Path.of("pom.xml");
+		var pom = Path.of("src/test/resources/valid-pom.xml");
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
-			"--v2=src/test/resources/test-project-v1/src",
 			"--api",
 			"--pom=" + pom,
-			"--api-json=" + api,
-			"--verbose");
+			"--api-json=" + api);
 
 		assertThat(exitCode).isZero();
-		assertThat(out.toString()).contains("Extracting classpath from " + pom);
 	}
 
 	@Test
@@ -262,8 +234,8 @@ class RoseauCLITest {
 			"--pom=src/test/resources/none.xml",
 			"--api-json=" + api);
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Cannot find pom:");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -272,8 +244,8 @@ class RoseauCLITest {
 			"--extractor=UNKNOWN",
 			"--api");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Invalid value for option '--extractor'");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -283,8 +255,8 @@ class RoseauCLITest {
 			"--extractor=ASM",
 			"--diff");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("ASM extractor cannot be used");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -294,8 +266,8 @@ class RoseauCLITest {
 			"--formatter=UNKNOWN",
 			"--diff");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Unknown option: '--formatter=UNKNOWN'");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	// --- Reports --- //
@@ -306,7 +278,19 @@ class RoseauCLITest {
 			"--diff");
 
 		assertThat(exitCode).isZero();
-		assertThat(Path.of("report.csv")).doesNotExist();
+	}
+
+	@Test
+	void write_report_without_format(@TempDir Path tempDir) {
+		var reportFile = tempDir.resolve("custom.csv");
+		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
+			"--v2=src/test/resources/test-project-v2/src",
+			"--diff",
+			"--report=" + reportFile);
+
+		assertThat(err.toString()).contains("--format required with --report");
+		assertThat(reportFile).doesNotExist();
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -315,11 +299,12 @@ class RoseauCLITest {
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
 			"--v2=src/test/resources/test-project-v2/src",
 			"--diff",
-			"--report=" + reportFile);
+			"--report=" + reportFile,
+			"--format=CSV");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -331,9 +316,9 @@ class RoseauCLITest {
 			"--format=HTML",
 			"--report=" + reportFile);
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -345,9 +330,9 @@ class RoseauCLITest {
 			"--format=JSON",
 			"--report=" + reportFile);
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -359,9 +344,9 @@ class RoseauCLITest {
 			"--format=MD",
 			"--report=" + reportFile);
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("Report has been written to " + reportFile);
 		assertThat(reportFile).isNotEmptyFile();
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -373,10 +358,11 @@ class RoseauCLITest {
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/src",
 			"--v2=src/test/resources/test-project-v2/src",
 			"--diff",
-			"--report=" + reportFile);
+			"--report=" + reportFile,
+			"--format=CSV");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Error writing report to " + reportFile);
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	// --- Ignored --- //
@@ -392,8 +378,8 @@ class RoseauCLITest {
 			"--ignored=" + ignored,
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).doesNotContain("METHOD_REMOVED pkg.T.m");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -402,7 +388,8 @@ class RoseauCLITest {
 		cmd.execute("--v1=src/test/resources/test-project-v1/test-project-v1.jar",
 			"--v2=src/test/resources/test-project-v2/test-project-v2.jar",
 			"--diff",
-			"--report=" + ignored);
+			"--report=" + ignored,
+			"--format=CSV");
 
 		var exitCode = cmd.execute("--v1=src/test/resources/test-project-v1/test-project-v1.jar",
 			"--v2=src/test/resources/test-project-v2/test-project-v2.jar",
@@ -410,8 +397,8 @@ class RoseauCLITest {
 			"--ignored=" + ignored,
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("No breaking changes found.");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -422,8 +409,8 @@ class RoseauCLITest {
 			"--diff",
 			"--ignored=" + invalidCsv);
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Cannot find ignored CSV: " + invalidCsv);
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -439,8 +426,8 @@ class RoseauCLITest {
 			"--ignored=" + malformedCsv,
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(err.toString()).contains("Malformed line");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -449,10 +436,10 @@ class RoseauCLITest {
 			"--api",
 			"--verbose");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString())
 			.contains("Cannot find v1:")
 			.contains("io.github.alien.roseau.RoseauException");
+		assertThat(exitCode).isEqualTo(2);
 	}
 
 	@Test
@@ -462,8 +449,8 @@ class RoseauCLITest {
 			"--diff",
 			"--plain");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).doesNotContain("\u001B[");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -472,8 +459,8 @@ class RoseauCLITest {
 			"--v2=src/test/resources/test-project-v2/src",
 			"--diff");
 
-		assertThat(exitCode).isZero();
 		assertThat(out.toString()).contains("\u001B[");
+		assertThat(exitCode).isZero();
 	}
 
 	@Test
@@ -482,7 +469,7 @@ class RoseauCLITest {
 			"--v2=src/test/resources/corrupt.jar",
 			"--diff");
 
-		assertThat(exitCode).isEqualTo(2);
 		assertThat(err.toString()).contains("Invalid path to library");
+		assertThat(exitCode).isEqualTo(2);
 	}
 }

--- a/cli/src/test/resources/valid-pom.xml
+++ b/cli/src/test/resources/valid-pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example</artifactId>
+    <version>0.0.1</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.5.0-jre</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,6 +81,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-paranamer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
         <!-- Drop that someday -->
         <dependency>
             <groupId>org.json</groupId>

--- a/core/src/main/java/io/github/alien/roseau/Library.java
+++ b/core/src/main/java/io/github/alien/roseau/Library.java
@@ -9,9 +9,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipFile;
 
@@ -19,12 +20,12 @@ import java.util.zip.ZipFile;
  * A library, in source or compiled form, provided for analysis.
  * <p>
  * The granularity of a library is that of a module, i.e., it should contain at most one module declaration
- * ({@code module-info.java}). If no module declaration is present, it is assumed that all packages within this library
+ * ({@code module-info.java}). If no module declaration is present, it is assumed that all names within this library
  * are implicitly exported. If a module declaration is present, the API accounts for unqualified {@code exports}
  * directives. The library points to a physical location that is either:
  * <ul>
- *   <li>A source directory containing nested packages and source files and one module declaration at most</li>
- *   <li>A {@code module-info.java} file. In this case, the directory containing the module is used as root directory</li>
+ *   <li>A source directory containing nested names and source files and one module declaration at most</li>
+ *   <li>A {@code module-info.java}. In this case, the directory containing the module is used as root directory</li>
  *   <li>A JAR file containing at most one {@code module-info.java} file</li>
  * </ul>
  * A library can be complemented with a custom classpath or a {@code pom.xml} file for dependency resolution. The
@@ -33,24 +34,28 @@ import java.util.zip.ZipFile;
  */
 public final class Library {
 	private final Path location;
-	private final List<Path> customClasspath;
+	private final Set<Path> customClasspath;
 	private final Path pom;
 	private final ExtractorType extractorType;
+	private final RoseauOptions.Exclude exclusions;
 	@JsonIgnore
-	private final Supplier<List<Path>> classpath;
+	private final Supplier<Set<Path>> classpath;
 
 	/**
 	 * Use the provided {@link #of(Path)} or {@link #builder()} instead.
 	 */
-	private Library(Path location, List<Path> customClasspath, Path pom, ExtractorType extractorType) {
+	private Library(Path location, Set<Path> customClasspath, Path pom, ExtractorType extractorType,
+	                RoseauOptions.Exclude exclusions) {
 		this.location = location.toAbsolutePath();
-		this.customClasspath = List.copyOf(customClasspath);
+		this.customClasspath = Set.copyOf(customClasspath);
 		this.pom = pom;
 		this.extractorType = extractorType;
+		this.exclusions = exclusions;
 		this.classpath = Suppliers.memoize(() -> {
 			if (pom != null && Files.isRegularFile(pom)) {
 				MavenClasspathBuilder builder = new MavenClasspathBuilder();
-				return Stream.concat(builder.buildClasspath(pom).stream(), customClasspath.stream()).toList();
+				return Stream.concat(builder.buildClasspath(pom).stream(), this.customClasspath.stream())
+					.collect(Collectors.toSet());
 			} else {
 				return this.customClasspath;
 			}
@@ -82,14 +87,14 @@ public final class Library {
 	/**
 	 * @return the user-defined classpath
 	 */
-	public List<Path> getCustomClasspath() {
+	public Set<Path> getCustomClasspath() {
 		return customClasspath;
 	}
 
 	/**
 	 * @return the resolved classpath, including custom classpath and pom-inferred classpath
 	 */
-	public List<Path> getClasspath() {
+	public Set<Path> getClasspath() {
 		return classpath.get();
 	}
 
@@ -146,6 +151,12 @@ public final class Library {
 		return Objects.hash(location, customClasspath, pom, extractorType);
 	}
 
+	@Override
+	public String toString() {
+		return "Library[location=%s, extractor=%s, classpath=%s, pom=%s, excludes=%s]".formatted(
+			location, extractorType, customClasspath, pom, exclusions);
+	}
+
 	/**
 	 * Builder class for constructing {@link Library} instances. Use the provided methods to set the physical location,
 	 * classpath, {@code pom.xml} file, and {@link ExtractorType} of the library, and invoke {@link #build()} to create
@@ -153,9 +164,10 @@ public final class Library {
 	 */
 	public static final class Builder {
 		private Path location;
-		private List<Path> classpath = List.of();
+		private Set<Path> classpath = Set.of();
 		private Path pom;
 		private ExtractorType extractorType;
+		private RoseauOptions.Exclude exclusions;
 
 		private Builder() {
 
@@ -178,7 +190,7 @@ public final class Library {
 		 * @param classpath the classpath
 		 * @return this builder
 		 */
-		public Builder classpath(List<Path> classpath) {
+		public Builder classpath(Set<Path> classpath) {
 			this.classpath = classpath;
 			return this;
 		}
@@ -205,6 +217,17 @@ public final class Library {
 			return this;
 		}
 
+		/**
+		 * Sets the names/types and annotations to exclude from the API.
+		 *
+		 * @param exclusions the excludes
+		 * @return this builder
+		 */
+		public Builder exclusions(RoseauOptions.Exclude exclusions) {
+			this.exclusions = exclusions;
+			return this;
+		}
+
 		private static boolean isValidLocation(Path location) {
 			return isModuleInfo(location) || isSources(location) || isJar(location);
 		}
@@ -219,14 +242,15 @@ public final class Library {
 				Integer.MAX_VALUE,
 				(Path p, BasicFileAttributes a) -> isModuleInfo(p)
 			)) {
-				return s.limit(2L).count() > 1L;  // short-circuits after the 2nd match
+				// short-circuits after the 2nd match
+				return s.limit(2L).count() > 1L;
 			} catch (IOException e) {
 				return false;
 			}
 		}
 
 		private static boolean isValidPom(Path pom) {
-			return Files.exists(pom) && Files.isRegularFile(pom) && pom.toString().endsWith(".xml");
+			return pom != null && Files.isRegularFile(pom) && pom.toString().endsWith(".xml");
 		}
 
 		/**
@@ -270,7 +294,7 @@ public final class Library {
 				throw new RoseauException("Source extractors cannot be used on JARs");
 			}
 
-			return new Library(location, classpath, pom, extractorType);
+			return new Library(location, classpath, pom, extractorType, exclusions);
 		}
 	}
 }

--- a/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
+++ b/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
@@ -11,63 +11,73 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public record RoseauOptions(Diff diff) {
-	public record Diff(Library v1, Library v2, Path ignore, List<Report> reports) {
-		public Diff mergeWith(Diff other) {
-			if (other == null) {
-				return this;
-			}
-			return new Diff(v1.mergeWith(other.v1()), v2.mergeWith(other.v2()),
-				either(other.ignore(), ignore), either(other.reports(), reports));
+public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, List<Report> reports) {
+	public record Common(ExtractorType extractor, Classpath classpath, Exclude excludes) {
+		Common mergeWith(Common other) {
+			return other != null
+				? new Common(either(other.extractor(), extractor), classpath.mergeWith(other.classpath()),
+					excludes.mergeWith(other.excludes()))
+				: this;
 		}
 	}
 
-	public record Library(Path location, ExtractorType extractor, Classpath classpath, Exclude excludes,
-	                      Path apiReport) {
-		public Library mergeWith(Library other) {
-			if (other == null) {
-				return this;
-			}
-			return new Library(
-				either(other.location(), location),
-				either(other.extractor(), extractor),
-				classpath.mergeWith(other.classpath()),
-				excludes.mergeWith(other.excludes()),
-				either(other.apiReport(), apiReport)
-			);
+	public record Library(Path location, ExtractorType extractor, Classpath classpath, Exclude excludes, Path apiReport) {
+		Library mergeWith(Library other) {
+			return other != null
+				? new Library(either(other.location(), location), either(other.extractor(), extractor),
+					classpath.mergeWith(other.classpath()), excludes.mergeWith(other.excludes()),
+					either(other.apiReport(), apiReport))
+				: this;
+		}
+
+		public Library mergeWith(Common common) {
+			return common != null
+				? new Library(location, either(extractor, common.extractor()), common.classpath().mergeWith(classpath),
+					common.excludes().mergeWith(excludes), apiReport)
+				: this;
+		}
+
+		public io.github.alien.roseau.Library toLibrary() {
+			return io.github.alien.roseau.Library.builder()
+				.location(location)
+				.classpath(classpath.jars())
+				.pom(classpath.pom())
+				.extractorType(extractor)
+				.exclusions(excludes)
+				.build();
 		}
 	}
 
 	public record Classpath(Path pom, Set<Path> jars) {
-		public Classpath mergeWith(Classpath other) {
-			if (other == null) {
-				return this;
-			}
-			return new Classpath(either(other.pom(), pom), either(other.jars(), jars));
+		Classpath mergeWith(Classpath other) {
+			return other != null
+				? new Classpath(either(other.pom(), pom), either(other.jars(), jars))
+				: this;
 		}
 	}
 
 	public record Exclude(List<String> names, List<AnnotationExclusion> annotations) {
-		public Exclude mergeWith(Exclude other) {
-			if (other == null) {
-				return this;
-			}
-			return new Exclude(either(other.names(), names), either(other.annotations(), annotations));
+		Exclude mergeWith(Exclude other) {
+			return other != null
+				? new Exclude(either(other.names(), names), either(other.annotations(), annotations))
+				: this;
 		}
 	}
 
 	public record AnnotationExclusion(String name, Map<String, String> args) {
 	}
 
-	public record Report(Path file, BreakingChangesFormatterFactory format) {}
+	public record Report(Path file, BreakingChangesFormatterFactory format) {
+
+	}
 
 	private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
 
-	public static RoseauOptions load(Path yamlPath) {
+	public static RoseauOptions load(Path yaml) {
 		try {
-			return newDefault().mergeWith(MAPPER.readValue(yamlPath.toFile(), RoseauOptions.class));
+			return newDefault().mergeWith(MAPPER.readValue(yaml.toFile(), RoseauOptions.class));
 		} catch (IOException e) {
-			throw new RoseauException("Couldn't read options file %s".formatted(yamlPath), e);
+			throw new RoseauException("Couldn't read options file %s".formatted(yaml), e);
 		}
 	}
 
@@ -75,12 +85,16 @@ public record RoseauOptions(Diff diff) {
 		Classpath defaultClasspath = new Classpath(null, Set.of());
 		Exclude defaultExclusion = new Exclude(List.of(), List.of());
 		Library defaultLibrary = new Library(null, null, defaultClasspath, defaultExclusion, null);
+		Common defaultCommon = new Common(null, defaultClasspath, defaultExclusion);
 		List<Report> defaultReports = List.of();
-		return new RoseauOptions(new Diff(defaultLibrary, defaultLibrary, null, defaultReports));
+		return new RoseauOptions(defaultCommon, defaultLibrary, defaultLibrary, null, defaultReports);
 	}
 
 	public RoseauOptions mergeWith(RoseauOptions other) {
-		return new RoseauOptions(diff.mergeWith(other.diff()));
+		return other != null
+			? new RoseauOptions(common.mergeWith(other.common()), v1.mergeWith(other.v1()), v2.mergeWith(other.v2()),
+			either(other.ignore(), ignore), either(other.reports(), reports))
+			: this;
 	}
 
 	private static <T> T either(T first, T second) {

--- a/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
+++ b/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
@@ -1,0 +1,97 @@
+package io.github.alien.roseau;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.github.alien.roseau.diff.formatter.BreakingChangesFormatterFactory;
+import io.github.alien.roseau.extractors.ExtractorType;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public record RoseauOptions(Diff diff) {
+	public record Diff(Library v1, Library v2, Path ignore, List<Report> reports) {
+		public Diff mergeWith(Diff other) {
+			if (other == null) {
+				return this;
+			}
+			return new Diff(v1.mergeWith(other.v1()), v2.mergeWith(other.v2()),
+				either(other.ignore(), ignore), either(other.reports(), reports));
+		}
+	}
+
+	public record Library(Path location, ExtractorType extractor, Classpath classpath, Exclude excludes,
+	                      Path apiReport) {
+		public Library mergeWith(Library other) {
+			if (other == null) {
+				return this;
+			}
+			return new Library(
+				either(other.location(), location),
+				either(other.extractor(), extractor),
+				classpath.mergeWith(other.classpath()),
+				excludes.mergeWith(other.excludes()),
+				either(other.apiReport(), apiReport)
+			);
+		}
+	}
+
+	public record Classpath(Path pom, Set<Path> jars) {
+		public Classpath mergeWith(Classpath other) {
+			if (other == null) {
+				return this;
+			}
+			return new Classpath(either(other.pom(), pom), either(other.jars(), jars));
+		}
+	}
+
+	public record Exclude(List<String> names, List<AnnotationExclusion> annotations) {
+		public Exclude mergeWith(Exclude other) {
+			if (other == null) {
+				return this;
+			}
+			return new Exclude(either(other.names(), names), either(other.annotations(), annotations));
+		}
+	}
+
+	public record AnnotationExclusion(String name, Map<String, String> args) {
+	}
+
+	public record Report(Path file, BreakingChangesFormatterFactory format) {}
+
+	private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+
+	public static RoseauOptions load(Path yamlPath) {
+		try {
+			return newDefault().mergeWith(MAPPER.readValue(yamlPath.toFile(), RoseauOptions.class));
+		} catch (IOException e) {
+			throw new RoseauException("Couldn't read options file %s".formatted(yamlPath), e);
+		}
+	}
+
+	public static RoseauOptions newDefault() {
+		Classpath defaultClasspath = new Classpath(null, Set.of());
+		Exclude defaultExclusion = new Exclude(List.of(), List.of());
+		Library defaultLibrary = new Library(null, null, defaultClasspath, defaultExclusion, null);
+		List<Report> defaultReports = List.of();
+		return new RoseauOptions(new Diff(defaultLibrary, defaultLibrary, null, defaultReports));
+	}
+
+	public RoseauOptions mergeWith(RoseauOptions other) {
+		return new RoseauOptions(diff.mergeWith(other.diff()));
+	}
+
+	private static <T> T either(T first, T second) {
+		return first != null ? first : second;
+	}
+
+	private static <T> List<T> either(List<T> first, List<T> second) {
+		return first != null && !first.isEmpty() ? first : second;
+	}
+
+	private static <T> Set<T> either(Set<T> first, Set<T> second) {
+		return first != null && !first.isEmpty() ? first : second;
+	}
+}

--- a/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
+++ b/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
@@ -11,29 +11,54 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Roseau's configuration options.
+ *
+ * @param common  options shared by v1 and v2
+ * @param v1      options specific to v1
+ * @param v2      options specific to v2
+ * @param ignore  the CSV "ignore" file to use
+ * @param reports reports configuration
+ */
 public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, List<Report> reports) {
+	/**
+	 * Options shared by v1 and v2
+	 *
+	 * @param extractor the {@link ExtractorType} to use
+	 * @param classpath the {@link Classpath} to use
+	 * @param excludes  the API {@link Exclude} options to apply
+	 */
 	public record Common(ExtractorType extractor, Classpath classpath, Exclude excludes) {
 		Common mergeWith(Common other) {
 			return other != null
 				? new Common(either(other.extractor(), extractor), classpath.mergeWith(other.classpath()),
-					excludes.mergeWith(other.excludes()))
+				excludes.mergeWith(other.excludes()))
 				: this;
 		}
 	}
 
+	/**
+	 * Options for a particular library, v1 or v2
+	 *
+	 * @param location  the location of the library
+	 * @param extractor the {@link ExtractorType} to use
+	 * @param classpath the {@link Classpath} to use
+	 * @param excludes  the API {@link Exclude} options to apply
+	 * @param apiReport the location of the API report to generate
+	 */
 	public record Library(Path location, ExtractorType extractor, Classpath classpath, Exclude excludes, Path apiReport) {
 		Library mergeWith(Library other) {
 			return other != null
 				? new Library(either(other.location(), location), either(other.extractor(), extractor),
-					classpath.mergeWith(other.classpath()), excludes.mergeWith(other.excludes()),
-					either(other.apiReport(), apiReport))
+				classpath.mergeWith(other.classpath()), excludes.mergeWith(other.excludes()),
+				either(other.apiReport(), apiReport))
 				: this;
 		}
 
 		public Library mergeWith(Common common) {
 			return common != null
 				? new Library(location, either(extractor, common.extractor()), common.classpath().mergeWith(classpath),
-					common.excludes().mergeWith(excludes), apiReport)
+				common.excludes().mergeWith(excludes), apiReport)
 				: this;
 		}
 
@@ -48,6 +73,12 @@ public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, 
 		}
 	}
 
+	/**
+	 * A classpath configuration for a library.
+	 *
+	 * @param pom  the path to the {@code pom.xml} to extract a classpath from
+	 * @param jars the manual classpath
+	 */
 	public record Classpath(Path pom, Set<Path> jars) {
 		Classpath mergeWith(Classpath other) {
 			return other != null
@@ -56,6 +87,12 @@ public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, 
 		}
 	}
 
+	/**
+	 * Exclusion options to apply to API inference.
+	 *
+	 * @param names       the list of regex-based names to be excluded
+	 * @param annotations the list of {@link AnnotationExclusion} to consider
+	 */
 	public record Exclude(List<String> names, List<AnnotationExclusion> annotations) {
 		Exclude mergeWith(Exclude other) {
 			return other != null
@@ -64,15 +101,34 @@ public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, 
 		}
 	}
 
+	/**
+	 * A particular code annotation that excludes the symbols it's applied to from the API
+	 *
+	 * @param name the fully qualified name of the annotation
+	 * @param args the argument values, if any
+	 */
 	public record AnnotationExclusion(String name, Map<String, String> args) {
 	}
 
+	/**
+	 * A report configuration for breaking changes.
+	 *
+	 * @param file   the path to the file where the report will be saved
+	 * @param format the format to apply when generating the report
+	 */
 	public record Report(Path file, BreakingChangesFormatterFactory format) {
 
 	}
 
 	private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
 
+	/**
+	 * Creates a new instance from the given YAML file.
+	 *
+	 * @param yaml the path to the YAML file containing the configuration
+	 * @return an instance representing the options
+	 * @throws RoseauException if an error occurs while reading or parsing the file
+	 */
 	public static RoseauOptions load(Path yaml) {
 		try {
 			return newDefault().mergeWith(MAPPER.readValue(yaml.toFile(), RoseauOptions.class));
@@ -81,6 +137,11 @@ public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, 
 		}
 	}
 
+	/**
+	 * A default empty instance.
+	 *
+	 * @return the empty instance
+	 */
 	public static RoseauOptions newDefault() {
 		Classpath defaultClasspath = new Classpath(null, Set.of());
 		Exclude defaultExclusion = new Exclude(List.of(), List.of());
@@ -90,6 +151,13 @@ public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, 
 		return new RoseauOptions(defaultCommon, defaultLibrary, defaultLibrary, null, defaultReports);
 	}
 
+	/**
+	 * Merges the current instance with another one, overriding any value with those present in {@code other}.
+	 *
+	 * @param other the {@code RoseauOptions} instance to merge with; may be null
+	 * @return a new {@code RoseauOptions} instance that represents the merged result, or the current instance if the
+	 * other instance is null
+	 */
 	public RoseauOptions mergeWith(RoseauOptions other) {
 		return other != null
 			? new RoseauOptions(common.mergeWith(other.common()), v1.mergeWith(other.v1()), v2.mergeWith(other.v2()),

--- a/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
+++ b/core/src/main/java/io/github/alien/roseau/RoseauOptions.java
@@ -7,6 +7,7 @@ import io.github.alien.roseau.extractors.ExtractorType;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -169,11 +170,7 @@ public record RoseauOptions(Common common, Library v1, Library v2, Path ignore, 
 		return first != null ? first : second;
 	}
 
-	private static <T> List<T> either(List<T> first, List<T> second) {
-		return first != null && !first.isEmpty() ? first : second;
-	}
-
-	private static <T> Set<T> either(Set<T> first, Set<T> second) {
+	private static <T, C extends Collection<T>> C either(C first, C second) {
 		return first != null && !first.isEmpty() ? first : second;
 	}
 }

--- a/core/src/main/java/io/github/alien/roseau/api/model/ClassDecl.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/ClassDecl.java
@@ -5,6 +5,7 @@ import io.github.alien.roseau.api.model.reference.TypeReference;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -26,7 +27,7 @@ public sealed class ClassDecl extends TypeDecl permits RecordDecl, EnumDecl {
 			implementedInterfaces, formalTypeParameters, fields, methods, enclosingType);
 		Preconditions.checkNotNull(constructors);
 		Preconditions.checkNotNull(permittedTypes);
-		this.superClass = superClass != null ? superClass : TypeReference.OBJECT;
+		this.superClass = Optional.ofNullable(superClass).orElse(TypeReference.OBJECT);
 		this.constructors = List.copyOf(constructors);
 		this.permittedTypes = List.copyOf(permittedTypes);
 	}

--- a/core/src/main/java/io/github/alien/roseau/api/model/LibraryTypes.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/LibraryTypes.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -103,7 +104,7 @@ public final class LibraryTypes implements TypeProvider {
 	 * @param classpath the classpath used for type resolution
 	 * @return the new resolved API
 	 */
-	public API toAPI(List<Path> classpath) {
+	public API toAPI(Set<Path> classpath) {
 		TypeProvider typeProvider = new SpoonTypeProvider(new CachingTypeReferenceFactory(), classpath);
 		return toAPI(new CachingTypeResolver(List.of(this, typeProvider)));
 	}
@@ -114,7 +115,7 @@ public final class LibraryTypes implements TypeProvider {
 	 * @return the new resolved API
 	 */
 	public API toAPI() {
-		return toAPI(List.of());
+		return toAPI(Set.of());
 	}
 
 	/**

--- a/core/src/main/java/io/github/alien/roseau/api/model/SourceLocation.java
+++ b/core/src/main/java/io/github/alien/roseau/api/model/SourceLocation.java
@@ -1,6 +1,7 @@
 package io.github.alien.roseau.api.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * A physical source location that points to a specific line in a file.
@@ -14,7 +15,7 @@ public record SourceLocation(
 	int line
 ) {
 	public SourceLocation(Path file, int line) {
-		this.file = file != null ? file.toAbsolutePath() : null;
+		this.file = Optional.ofNullable(file).map(Path::toAbsolutePath).orElse(null);
 		this.line = line;
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/api/resolution/SpoonTypeProvider.java
+++ b/core/src/main/java/io/github/alien/roseau/api/resolution/SpoonTypeProvider.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A type provider implementation that creates new type declarations reflectively to represent and navigate types
@@ -27,7 +28,7 @@ public class SpoonTypeProvider implements TypeProvider {
 	 * @param typeReferenceFactory the {@link TypeReferenceFactory} to create new type references with
 	 * @param classpath            the classpath used to find the requested types
 	 */
-	public SpoonTypeProvider(TypeReferenceFactory typeReferenceFactory, List<Path> classpath) {
+	public SpoonTypeProvider(TypeReferenceFactory typeReferenceFactory, Set<Path> classpath) {
 		Preconditions.checkNotNull(typeReferenceFactory);
 		Preconditions.checkNotNull(classpath);
 		spoonFactory = new SpoonAPIFactory(typeReferenceFactory, classpath);

--- a/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/APIDiff.java
@@ -63,7 +63,7 @@ public class APIDiff {
 	/**
 	 * Diff the two APIs to detect breaking changes.
 	 *
-	 * @return the report built for the two APIs
+	 * @return the apiReport built for the two APIs
 	 */
 	public RoseauReport diff() {
 		v1.getExportedTypes().stream().parallel().forEach(t1 ->

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/BreakingChangesFormatter.java
@@ -1,6 +1,5 @@
 package io.github.alien.roseau.diff.formatter;
 
-import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.RoseauReport;
 
 /**
@@ -8,10 +7,10 @@ import io.github.alien.roseau.diff.RoseauReport;
  */
 public interface BreakingChangesFormatter {
 	/**
-	 * Returns a string representation of the supplied report
+	 * Returns a string representation of the supplied apiReport
 	 *
-	 * @param report the report to format
+	 * @param report the apiReport to format
 	 * @return the formatted list
 	 */
-	String format(API api, RoseauReport report);
+	String format(RoseauReport report);
 }

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/CsvFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/CsvFormatter.java
@@ -1,6 +1,5 @@
 package io.github.alien.roseau.diff.formatter;
 
-import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.RoseauReport;
 
 import java.util.stream.Collectors;
@@ -12,7 +11,7 @@ public class CsvFormatter implements BreakingChangesFormatter {
 	public static final String HEADER = "type;symbol;kind;nature";
 
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		return HEADER + System.lineSeparator() +
 			report.breakingChanges().stream().map(bc -> "%s;%s;%s;%s".formatted(
 				bc.impactedType().getQualifiedName(),

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/HtmlFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/HtmlFormatter.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  */
 public class HtmlFormatter implements BreakingChangesFormatter {
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		StringBuilder sb = new StringBuilder();
 		HtmlFlow.doc(sb)
 			.html()
@@ -42,7 +42,7 @@ public class HtmlFormatter implements BreakingChangesFormatter {
 			.div().addAttr("class", "container mt-5")
 			.h1().text("Breaking Changes Report").__()
 			.table().addAttr("class", "table")
-			.of(table -> getImpactedApiTree(api, report.breakingChanges()).forEach(node ->
+			.of(table -> getImpactedApiTree(report.v1(), report.breakingChanges()).forEach(node ->
 				table.tr().of(tr -> appendNode(tr, node)).__()
 					.of(theTable -> node.children.forEach(member -> theTable.tr().of(tr -> appendNode(tr, member)).__()))
 			))

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/JsonFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/JsonFormatter.java
@@ -1,6 +1,5 @@
 package io.github.alien.roseau.diff.formatter;
 
-import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.api.model.SourceLocation;
 import io.github.alien.roseau.diff.RoseauReport;
 import io.github.alien.roseau.diff.changes.BreakingChange;
@@ -15,7 +14,7 @@ public class JsonFormatter implements BreakingChangesFormatter {
 	 * Formats the list of breaking changes in JSON format
 	 */
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		JSONArray jsonArray = new JSONArray();
 
 		for (BreakingChange bc : report.breakingChanges()) {

--- a/core/src/main/java/io/github/alien/roseau/diff/formatter/MdFormatter.java
+++ b/core/src/main/java/io/github/alien/roseau/diff/formatter/MdFormatter.java
@@ -1,6 +1,5 @@
 package io.github.alien.roseau.diff.formatter;
 
-import io.github.alien.roseau.api.model.API;
 import io.github.alien.roseau.diff.RoseauReport;
 import io.github.alien.roseau.diff.changes.BreakingChange;
 
@@ -12,7 +11,7 @@ public class MdFormatter implements BreakingChangesFormatter {
 	 * Formats the list of breaking changes in Markdown format
 	 */
 	@Override
-	public String format(API api, RoseauReport report) {
+	public String format(RoseauReport report) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("## Roseau - Breaking Changes Report\n");
 
@@ -26,8 +25,8 @@ public class MdFormatter implements BreakingChangesFormatter {
 			sb.append("|---------|--------------|--------------|------|--------|\n");
 			for (BreakingChange bc : report.breakingChanges()) {
 				sb.append("| ")
-						.append(bc.impactedSymbol().getQualifiedName()).append(" | ")
-						.append(bc.impactedSymbol().getLocation().file()).append(":").append(bc.impactedSymbol().getLocation().line()).append(" | ");
+					.append(bc.impactedSymbol().getQualifiedName()).append(" | ")
+					.append(bc.impactedSymbol().getLocation().file()).append(":").append(bc.impactedSymbol().getLocation().line()).append(" | ");
 
 				if (bc.newSymbol() != null) {
 					sb.append(bc.newSymbol().getLocation().file()).append(":").append(bc.newSymbol().getLocation().line());
@@ -36,8 +35,8 @@ public class MdFormatter implements BreakingChangesFormatter {
 				}
 
 				sb.append(" | ")
-						.append(bc.kind()).append(" | ")
-						.append(bc.kind().getNature()).append(" |\n");
+					.append(bc.kind()).append(" | ")
+					.append(bc.kind().getNature()).append(" |\n");
 			}
 		}
 

--- a/core/src/main/java/io/github/alien/roseau/extractors/MavenClasspathBuilder.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/MavenClasspathBuilder.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Utility class to automatically infer the classpath of a Maven library. This implementation attempts to retrieve the
@@ -33,7 +35,7 @@ public class MavenClasspathBuilder {
 	 * @param pom the {@code pom.xml} file
 	 * @return the retrieved classpath or an empty list if something went wrong
 	 */
-	public List<Path> buildClasspath(Path pom) {
+	public Set<Path> buildClasspath(Path pom) {
 		Preconditions.checkNotNull(pom);
 		Path parent = pom.toAbsolutePath().getParent();
 
@@ -53,9 +55,10 @@ public class MavenClasspathBuilder {
 
 				if (result.getExitCode() == 0 && Files.isRegularFile(classpathFile)) {
 					String cpString = Files.readString(classpathFile);
+					LOGGER.debug("Extracted classpath from {}", pom);
 					return Arrays.stream(cpString.split(File.pathSeparator))
 						.map(Path::of)
-						.toList();
+						.collect(Collectors.toSet());
 				} else {
 					LOGGER.warn("Failed to build Maven classpath from {}", pom, result.getExecutionException());
 				}
@@ -73,7 +76,7 @@ public class MavenClasspathBuilder {
 			}
 		}
 
-		return List.of();
+		return Set.of();
 	}
 
 	private static InvocationRequest makeClasspathRequest(Path pom, Path classpathFile) {

--- a/core/src/main/java/io/github/alien/roseau/extractors/jdt/JdtAPIVisitor.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/jdt/JdtAPIVisitor.java
@@ -58,6 +58,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 final class JdtAPIVisitor extends ASTVisitor {
@@ -73,8 +74,8 @@ final class JdtAPIVisitor extends ASTVisitor {
 
 	JdtAPIVisitor(CompilationUnit cu, String filePath, TypeReferenceFactory factory) {
 		this.cu = cu;
-		this.packageName = cu.getPackage() != null ? cu.getPackage().getName().getFullyQualifiedName() : "";
-		this.filePath = filePath != null ? Paths.get(filePath) : null;
+		this.packageName = Optional.ofNullable(cu.getPackage()).map(p -> p.getName().getFullyQualifiedName()).orElse("");
+		this.filePath = Optional.ofNullable(filePath).map(Paths::get).orElse(null);
 		this.typeRefFactory = factory;
 	}
 
@@ -338,19 +339,17 @@ final class JdtAPIVisitor extends ASTVisitor {
 
 	private String formatAnnotationValue(Object value) {
 		return switch (value) {
-			case Object[] array ->
-				Arrays.stream(array)
-					.map(this::formatAnnotationValue)
-					.toList()
-					.toString();
+			case Object[] array -> Arrays.stream(array)
+				.map(this::formatAnnotationValue)
+				.toList()
+				.toString();
 			case IVariableBinding varBinding ->
 				// Enum constant
 				varBinding.getDeclaringClass().getQualifiedName() + "." + varBinding.getName();
 			case ITypeBinding typeBinding ->
 				// Class literal
 				typeBinding.getQualifiedName();
-			default ->
-				value.toString();
+			default -> value.toString();
 		};
 	}
 

--- a/core/src/main/java/io/github/alien/roseau/extractors/jdt/JdtTypesExtractor.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/jdt/JdtTypesExtractor.java
@@ -100,7 +100,7 @@ public class JdtTypesExtractor implements TypesExtractor {
 					// Actual parsing errors are just warnings for us
 					Arrays.stream(problems)
 						.filter(IProblem::isError)
-						.forEach(p -> LOGGER.warn("{} [{}:{}]: {}", p.isError() ? "error" : "warning",
+						.forEach(p -> LOGGER.warn("JDT {} [{}:{}]: {}", p.isError() ? "error" : "warning",
 							sourceFilePath, p.getSourceLineNumber(), p.getMessage()));
 				}
 

--- a/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonAPIFactory.java
@@ -76,6 +76,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -89,7 +90,7 @@ public class SpoonAPIFactory {
 
 	private static final Logger LOGGER = LogManager.getLogger(SpoonAPIFactory.class);
 
-	public SpoonAPIFactory(TypeReferenceFactory typeReferenceFactory, List<Path> classpath) {
+	public SpoonAPIFactory(TypeReferenceFactory typeReferenceFactory, Set<Path> classpath) {
 		Factory spoonFactory = new Launcher().createFactory();
 		spoonFactory.getEnvironment().setSourceClasspath(
 			sanitizeClasspath(classpath).stream()
@@ -100,7 +101,7 @@ public class SpoonAPIFactory {
 	}
 
 	// Avoid having Spoon throwing at us due to "invalid" classpath
-	private List<Path> sanitizeClasspath(List<Path> classpath) {
+	private List<Path> sanitizeClasspath(Set<Path> classpath) {
 		return classpath.stream()
 			.map(Path::toFile)
 			.filter(File::exists)
@@ -483,7 +484,7 @@ public class SpoonAPIFactory {
 		return switch (value) {
 			case CtLiteral<?> literal -> {
 				var lit = literal.getValue();
-				yield lit != null ? lit.toString() : "null";
+				yield Optional.ofNullable(lit).map(Object::toString).orElse("null");
 			}
 			case CtFieldRead<?> field -> {
 				var variable = field.getVariable();

--- a/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonUtils.java
+++ b/core/src/main/java/io/github/alien/roseau/extractors/spoon/SpoonUtils.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +50,7 @@ public final class SpoonUtils {
 	 * @throws RoseauException If there is an error in building the Spoon model
 	 */
 	public static CtModel buildModel(Launcher launcher, Path location, Duration timeout) {
-		long timeoutSeconds = timeout != null ? timeout.getSeconds() : Long.MAX_VALUE;
+		long timeoutSeconds = Optional.ofNullable(timeout).map(Duration::getSeconds).orElse(Long.MAX_VALUE);
 		CompletableFuture<CtModel> future = CompletableFuture.supplyAsync(launcher::buildModel);
 
 		try {

--- a/core/src/test/java/io/github/alien/roseau/LibraryTest.java
+++ b/core/src/test/java/io/github/alien/roseau/LibraryTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -86,7 +87,7 @@ class LibraryTest {
 	@Test
 	void builder_with_all_parameters_set(@TempDir Path tempDir) throws IOException {
 		var pom = tempDir.resolve("pom.xml");
-		var cp = List.of(tempDir.resolve("cp"));
+		var cp = Set.of(tempDir.resolve("cp"));
 		Files.createFile(pom);
 
 		var lib = Library.builder()
@@ -105,7 +106,7 @@ class LibraryTest {
 	@Test
 	void classpath_merges_custom_and_pom() {
 		var pom = Path.of("pom.xml"); // Roseau's pom.xml
-		var cp = List.of(Path.of("cp"));
+		var cp = Set.of(Path.of("cp"));
 
 		var lib = Library.builder()
 			.location(validJar)

--- a/core/src/test/java/io/github/alien/roseau/RoseauOptionsTest.java
+++ b/core/src/test/java/io/github/alien/roseau/RoseauOptionsTest.java
@@ -1,0 +1,175 @@
+package io.github.alien.roseau;
+
+import io.github.alien.roseau.diff.formatter.BreakingChangesFormatterFactory;
+import io.github.alien.roseau.extractors.ExtractorType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoseauOptionsTest {
+	@Test
+	void merge_with_null_is_this() {
+		var base = RoseauOptions.newDefault();
+		assertThat(base.mergeWith(null)).isSameAs(base);
+		assertThat(base.common().mergeWith(null)).isSameAs(base.common());
+		assertThat(base.v1().mergeWith((RoseauOptions.Library) null)).isSameAs(base.v1());
+		assertThat(base.v1().mergeWith((RoseauOptions.Common) null)).isSameAs(base.v1());
+		assertThat(base.v1().classpath().mergeWith(null)).isSameAs(base.v1().classpath());
+		assertThat(base.v1().excludes().mergeWith(null)).isSameAs(base.v1().excludes());
+	}
+
+	@Test
+	void merge_overrides_existing() {
+		var cpBase = new RoseauOptions.Classpath(Path.of("base-pom.xml"), Set.of(Path.of("base.jar")));
+		var exBase = new RoseauOptions.Exclude(
+			List.of("base.*"), List.of(new RoseauOptions.AnnotationExclusion("BaseAnn", Map.of("baseK", "baseV"))));
+		var commonBase = new RoseauOptions.Common(ExtractorType.ASM, cpBase, exBase);
+		var libBase = new RoseauOptions.Library(
+			Path.of("base-lib"), ExtractorType.ASM, cpBase, exBase, Path.of("base.json"));
+		var base = new RoseauOptions(commonBase, libBase, libBase, Path.of("base-ignore.csv"),
+			List.of(new RoseauOptions.Report(Path.of("base.csv"), BreakingChangesFormatterFactory.CSV)));
+
+		var cpOther = new RoseauOptions.Classpath(Path.of("other-pom.xml"), Set.of(Path.of("other.jar")));
+		var exOther = new RoseauOptions.Exclude(
+			List.of("other.*"), List.of(new RoseauOptions.AnnotationExclusion("OtherAnn", Map.of("otherK", "otherV"))));
+		var commonOther = new RoseauOptions.Common(ExtractorType.JDT, cpOther, exOther);
+		var libOther = new RoseauOptions.Library(
+			Path.of("other-lib"), ExtractorType.JDT, cpOther, exOther, Path.of("other.json"));
+		var other = new RoseauOptions(commonOther, libOther, libOther, Path.of("other-ignore.csv"),
+			List.of(new RoseauOptions.Report(Path.of("other.html"), BreakingChangesFormatterFactory.HTML)));
+
+		var merged = base.mergeWith(other);
+
+		assertThat(merged.ignore()).isEqualTo(Path.of("other-ignore.csv"));
+		assertThat(merged.reports()).singleElement().isEqualTo(
+			new RoseauOptions.Report(Path.of("other.html"), BreakingChangesFormatterFactory.HTML));
+
+		assertThat(merged.common().extractor()).isEqualTo(ExtractorType.JDT);
+		assertThat(merged.common().classpath().pom()).isEqualTo(Path.of("other-pom.xml"));
+		assertThat(merged.common().classpath().jars()).containsExactly(Path.of("other.jar"));
+		assertThat(merged.common().excludes().names()).containsExactly("other.*");
+		assertThat(merged.common().excludes().annotations()).singleElement().isEqualTo(
+			new RoseauOptions.AnnotationExclusion("OtherAnn", Map.of("otherK", "otherV")));
+
+		assertThat(merged.v1().location()).isEqualTo(Path.of("other-lib"));
+		assertThat(merged.v1().extractor()).isEqualTo(ExtractorType.JDT);
+		assertThat(merged.v1().apiReport()).isEqualTo(Path.of("other.json"));
+		assertThat(merged.v1().classpath().pom()).isEqualTo(Path.of("other-pom.xml"));
+		assertThat(merged.v1().classpath().jars()).containsExactly(Path.of("other.jar"));
+		assertThat(merged.v1().excludes().names()).containsExactly("other.*");
+
+		assertThat(merged.v2()).isEqualTo(merged.v1());
+	}
+
+	@Test
+	void merge_does_not_override_with_null_or_empty() {
+		var cpBase = new RoseauOptions.Classpath(Path.of("base-pom.xml"), Set.of(Path.of("base.jar")));
+		var exBase = new RoseauOptions.Exclude(
+			List.of("base.*"), List.of(new RoseauOptions.AnnotationExclusion("BaseAnn", Map.of("baseK", "baseV"))));
+		var commonBase = new RoseauOptions.Common(ExtractorType.ASM, cpBase, exBase);
+		var libBase = new RoseauOptions.Library(
+			Path.of("base-lib"), ExtractorType.ASM, cpBase, exBase, Path.of("base.json"));
+		var base = new RoseauOptions(commonBase, libBase, libBase, Path.of("base-ignore.csv"),
+			List.of(new RoseauOptions.Report(Path.of("base.csv"), BreakingChangesFormatterFactory.CSV)));
+
+		var cpOther = new RoseauOptions.Classpath(null, Set.of());
+		var exOther = new RoseauOptions.Exclude(List.of(), List.of());
+		var commonOther = new RoseauOptions.Common(null, cpOther, exOther);
+		var libOther = new RoseauOptions.Library(null, null, cpOther, exOther, null);
+		var other = new RoseauOptions(commonOther, libOther, libOther, null, List.of());
+
+		var merged = base.mergeWith(other);
+		assertThat(merged).isEqualTo(base);
+	}
+
+	@Test
+	void merge_with_common_overrides_when_not_set() {
+		var cpCommon = new RoseauOptions.Classpath(Path.of("common-pom.xml"), Set.of(Path.of("common.jar")));
+		var exCommon = new RoseauOptions.Exclude(
+			List.of("common.*"), List.of(new RoseauOptions.AnnotationExclusion("CommonAnn", Map.of("commonK", "commonV"))));
+		var common = new RoseauOptions.Common(ExtractorType.JDT, cpCommon, exCommon);
+
+		var cpSet = new RoseauOptions.Classpath(Path.of("set-pom.xml"), Set.of(Path.of("set.jar")));
+		var exSet = new RoseauOptions.Exclude(
+			List.of("set.*"), List.of(new RoseauOptions.AnnotationExclusion("SetAnn", Map.of("setK", "setV"))));
+		var set = new RoseauOptions.Library(Path.of("set"), ExtractorType.ASM, cpSet, exSet, Path.of("a.json"));
+
+		var cpUnset = new RoseauOptions.Classpath(null, Set.of());
+		var exUnset = new RoseauOptions.Exclude(List.of(), List.of());
+		var unset = new RoseauOptions.Library(Path.of("unset"), null, cpUnset, exUnset, Path.of("a.json"));
+
+		var mergedWithSet = set.mergeWith(common);
+		assertThat(mergedWithSet).isEqualTo(set);
+
+		var mergedWithUnset = unset.mergeWith(common);
+		assertThat(mergedWithUnset.location()).isEqualTo(Path.of("unset"));
+		assertThat(mergedWithUnset.extractor()).isEqualTo(ExtractorType.JDT);
+		assertThat(mergedWithUnset.classpath()).isEqualTo(cpCommon);
+		assertThat(mergedWithUnset.excludes()).isEqualTo(exCommon);
+		assertThat(mergedWithUnset.apiReport()).isEqualTo(Path.of("a.json"));
+	}
+
+	@Test
+	void load_sets_values(@TempDir Path tmp) throws IOException {
+		var yaml = tmp.resolve("opts.yaml");
+		var content = """
+			common:
+			  extractor: JDT
+			  classpath:
+			    pom: /pom.xml
+			    jars: [/cp/a.jar, /cp/b.jar]
+			  excludes:
+			    names: [com.acme.*]
+			    annotations:
+			      - name: java.lang.Deprecated
+			        args: { since: 1.0 }
+			v1:
+			  location: /lib/v1
+			  extractor: JDT
+			  classpath:
+			    jars: [/v1.jar]
+			  excludes:
+			    names: [x]
+			  apiReport: /api/v1.json
+			v2:
+			  location: /lib/v2
+			  extractor: ASM
+			  classpath:
+			    jars: [/v2.jar]
+			  excludes:
+			    names: [y]
+			  apiReport: /api/v2.json
+			ignore: /ignore.yaml
+			reports:
+			  - file: /report.csv
+			    format: CSV
+			  - file: /report.html
+			    format: HTML
+			""";
+		Files.writeString(yaml, content);
+
+		var options = RoseauOptions.load(yaml);
+
+		assertThat(options.common().extractor()).isEqualTo(ExtractorType.JDT);
+		assertThat(options.common().classpath().pom()).isEqualTo(Path.of("/pom.xml"));
+		assertThat(options.common().classpath().jars()).contains(Path.of("/cp/a.jar"), Path.of("/cp/b.jar"));
+		assertThat(options.common().excludes().names()).containsExactly("com.acme.*");
+		assertThat(options.common().excludes().annotations()).hasSize(1);
+		assertThat(options.v1().location()).isEqualTo(Path.of("/lib/v1"));
+		assertThat(options.v1().apiReport()).isEqualTo(Path.of("/api/v1.json"));
+		assertThat(options.v2().location()).isEqualTo(Path.of("/lib/v2"));
+		assertThat(options.v2().extractor()).isEqualTo(ExtractorType.ASM);
+		assertThat(options.ignore()).isEqualTo(Path.of("/ignore.yaml"));
+		assertThat(options.reports()).containsExactly(
+			new RoseauOptions.Report(Path.of("/report.csv"), BreakingChangesFormatterFactory.CSV),
+			new RoseauOptions.Report(Path.of("/report.html"), BreakingChangesFormatterFactory.HTML));
+	}
+}

--- a/core/src/test/java/io/github/alien/roseau/api/model/LibraryTypesTest.java
+++ b/core/src/test/java/io/github/alien/roseau/api/model/LibraryTypesTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -83,7 +84,7 @@ class LibraryTypesTest {
 	void json_round_trip() throws IOException {
 		Path sources = Path.of("src/main/java");
 		MavenClasspathBuilder builder = new MavenClasspathBuilder();
-		List<Path> classpath = builder.buildClasspath(Path.of("pom.xml"));
+		Set<Path> classpath = builder.buildClasspath(Path.of("pom.xml"));
 		Library library = Library.builder().location(sources).classpath(classpath).build();
 		TypesExtractor extractor = new JdtTypesExtractor();
 		LibraryTypes orig = extractor.extractTypes(library);

--- a/core/src/test/java/io/github/alien/roseau/api/resolution/SpoonTypeProviderTest.java
+++ b/core/src/test/java/io/github/alien/roseau/api/resolution/SpoonTypeProviderTest.java
@@ -7,19 +7,19 @@ import io.github.alien.roseau.api.model.reference.TypeReference;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SpoonTypeProviderTest {
-	SpoonTypeProvider newProvider(List<Path> classpath) {
+	SpoonTypeProvider newProvider(Set<Path> classpath) {
 		CachingTypeReferenceFactory factory = new CachingTypeReferenceFactory();
 		return new SpoonTypeProvider(factory, classpath);
 	}
 
 	@Test
 	void resolve_jdk() {
-		var cp = List.<Path>of();
+		var cp = Set.<Path>of();
 		var provider = newProvider(cp);
 		var opt = provider.findType("java.lang.Number", ClassDecl.class);
 
@@ -38,7 +38,7 @@ class SpoonTypeProviderTest {
 
 	@Test
 	void resolve_unknown() {
-		var cp = List.<Path>of();
+		var cp = Set.<Path>of();
 		var provider = newProvider(cp);
 		var opt = provider.findType("java.lang.Unknown");
 
@@ -48,7 +48,7 @@ class SpoonTypeProviderTest {
 	@Test
 	void resolve_with_classpath() {
 		var showcase = Path.of("src/test/resources/api-showcase.jar");
-		var cp = List.of(showcase);
+		var cp = Set.of(showcase);
 		var provider = newProvider(cp);
 		var opt = provider.findType("io.github.alien.roseau.APIShowcase$Square", ClassDecl.class);
 
@@ -67,7 +67,7 @@ class SpoonTypeProviderTest {
 
 	@Test
 	void resolve_unexpected_kind() {
-		var provider = newProvider(List.of());
+		var provider = newProvider(Set.of());
 		var opt = provider.findType("java.lang.Number", InterfaceDecl.class);
 
 		assertThat(opt).isEmpty();
@@ -75,7 +75,7 @@ class SpoonTypeProviderTest {
 
 	@Test
 	void resolve_unexpected_kind_sub() {
-		var provider = newProvider(List.of());
+		var provider = newProvider(Set.of());
 		var opt = provider.findType("java.time.DayOfWeek", ClassDecl.class);
 
 		assertThat(opt).isPresent();

--- a/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
+++ b/core/src/test/java/io/github/alien/roseau/diff/ClassTypeChangedTest.java
@@ -28,7 +28,7 @@ class ClassTypeChangedTest {
 		assertBC("A", "A", BreakingChangeKind.CLASS_TYPE_CHANGED, 1, buildDiff(v1, v2));
 	}
 
-	@Disabled("Not sure about this one; we might still want to report it.")
+	@Disabled("Not sure about this one; we might still want to apiReport it.")
 	@Client("A a = new A();")
 	@Test
 	void final_class_to_record() {

--- a/core/src/test/java/io/github/alien/roseau/smoke/JdkTestIT.java
+++ b/core/src/test/java/io/github/alien/roseau/smoke/JdkTestIT.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +43,7 @@ class JdkTestIT {
 			fail("No sources for " + jmod);
 
 		var sw = Stopwatch.createUnstarted();
-		var classpath = jmods().filter(mod -> !mod.equals(jmod)).toList();
+		var classpath = jmods().filter(mod -> !mod.equals(jmod)).collect(Collectors.toSet());
 		var srcLibrary = Library.builder()
 			.location(src)
 			.classpath(classpath)
@@ -74,7 +75,7 @@ class JdkTestIT {
 			fail("No sources for " + jmod);
 
 		var sw = Stopwatch.createUnstarted();
-		var classpath = jmods().filter(mod -> !mod.equals(jmod)).toList();
+		var classpath = jmods().filter(mod -> !mod.equals(jmod)).collect(Collectors.toSet());
 		var srcLibrary = Library.builder()
 			.location(src)
 			.classpath(classpath)
@@ -100,7 +101,7 @@ class JdkTestIT {
 	@Timeout(value = 1, unit = TimeUnit.MINUTES)
 	void jdk21Asm(Path jmod) {
 		var sw = Stopwatch.createUnstarted();
-		var classpath = jmods().filter(mod -> !mod.equals(jmod)).toList();
+		var classpath = jmods().filter(mod -> !mod.equals(jmod)).collect(Collectors.toSet());
 		var jarLibrary = Library.builder()
 			.location(jmod)
 			.classpath(classpath)

--- a/core/src/test/java/io/github/alien/roseau/smoke/PopularLibrariesTestIT.java
+++ b/core/src/test/java/io/github/alien/roseau/smoke/PopularLibrariesTestIT.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -101,7 +102,7 @@ class PopularLibrariesTestIT {
 		var sw = Stopwatch.createUnstarted();
 		var binaryJar = binaryJars.get(libraryGAV);
 		var sourcesDir = sourcesDirs.get(libraryGAV);
-		var classpath = classpaths.get(libraryGAV).stream().toList();
+		var classpath = classpaths.get(libraryGAV).stream().collect(Collectors.toSet());
 		var asmLibrary = Library.builder()
 			.location(binaryJar)
 			.classpath(classpath)
@@ -302,7 +303,7 @@ class PopularLibrariesTestIT {
 				Path sourcesDir = extractSourcesJar(sourcesJar);
 
 				try {
-					List<Path> classpath = new MavenClasspathBuilder().buildClasspath(pom);
+					Set<Path> classpath = new MavenClasspathBuilder().buildClasspath(pom);
 					classpaths.putAll(libraryGAV, classpath);
 				} catch (Exception e) {
 					e.printStackTrace();


### PR DESCRIPTION
Handling all the configuration options is getting messy; with this PR:

- [X] CLI can take an external `--config` YAML file; all options are... optional
- [X] Options in the YAML file override default options; CLI options override YAML options
- [X] Align CLI with YAML capabilities: including `--[v1|v2]-[classpath/pom/extractorType]`

Example YAML syntax is as follows. Can be complemented with a simple `roseau --diff --v1 <path> --v2 <path> --config lib.yaml` that gathers the remainder of the configuration from the file:

```yaml
common:
  excludes:
    names: [ com.google.common.base.Preconditions.* ]
    annotations:
      - name: com.google.common.annotations.Beta
        args:
          status: INTERNAL

v1:
  classpath:
    pom: /data/guava-21/pom.xml
    jars: [ path/to/lib.jar ]
  apiReport: ./reports/guava-v1.json

v2:
  classpath:
    pom: /data/guava-33/pom.xml
  excludes:
    annotations:
      - name: com.google.common.annotations.Another

ignore: ignored-bcs.csv

reports:
  - file: ./reports/guava.html
    format: HTML
  - file: ./reports/guava.csv
    format: CSV
```